### PR TITLE
feat: HTTP API wrapper for file download and album management

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -26,7 +26,7 @@ import {
   getDeviceInfo,
   albumListMediaInfos,
   fileDownloadUrl,
-} from "dwarfii_api/src/http_api.js";
+} from "dwarfii_api";
 
 const IP = "192.168.88.1";
 
@@ -373,7 +373,7 @@ await albumDelete("192.168.88.1", [
 ### URL の組み立て
 
 ```javascript
-import { fileDownloadUrl, downloadFile } from "dwarfii_api/src/http_api.js";
+import { fileDownloadUrl, downloadFile } from "dwarfii_api";
 
 // URL を取得 (ブラウザで開く場合など)
 const url = fileDownloadUrl("192.168.88.1", "/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits");
@@ -414,7 +414,7 @@ import {
   albumListMediaInfos,
   albumAstroFitsList,
   downloadFile,
-} from "dwarfii_api/src/http_api.js";
+} from "dwarfii_api";
 import { writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 
@@ -453,7 +453,7 @@ MJPEG ストリームは HTTP で直接取得できます。
 ### メインストリーム (望遠カメラ)
 
 ```javascript
-import { mainstreamUrl } from "dwarfii_api/src/http_api.js";
+import { mainstreamUrl } from "dwarfii_api";
 
 const url = mainstreamUrl("192.168.88.1");
 // => "http://192.168.88.1:8082/mainstream"
@@ -473,7 +473,7 @@ ffmpeg -i http://192.168.88.1:8082/mainstream -c copy output.mjpeg
 ### セカンドストリーム (広角カメラ)
 
 ```javascript
-import { secondstreamUrl } from "dwarfii_api/src/http_api.js";
+import { secondstreamUrl } from "dwarfii_api";
 
 const url = secondstreamUrl("192.168.88.1");
 // => "http://192.168.88.1:8082/secondstream"

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,0 +1,488 @@
+# HTTP API リファレンス
+
+DWARF mini / II / 3 が提供する HTTP API (ポート 8082) のリファレンスです。
+pcap 解析により発見されたエンドポイントを網羅しています。
+
+## 目次
+
+- [概要](#概要)
+- [MediaType 一覧](#mediatype-一覧)
+- [デバイス情報](#デバイス情報)
+- [撮影モード](#撮影モード)
+- [アルバム管理](#アルバム管理)
+- [ファイルダウンロード](#ファイルダウンロード)
+- [ストリーミング](#ストリーミング)
+
+---
+
+## 概要
+
+- ベース URL: `http://<DEVICE_IP>:8082`
+- POST リクエストは `Content-Type: application/json`
+- レスポンスは JSON 形式、成功時 `code: 0`
+
+```javascript
+import {
+  getDeviceInfo,
+  albumListMediaInfos,
+  fileDownloadUrl,
+} from "dwarfii_api/src/http_api.js";
+
+const IP = "192.168.88.1";
+
+// デバイス情報を取得
+const info = await getDeviceInfo(IP);
+console.log(info);
+
+// アルバム一覧を取得してFITSファイルをダウンロード
+const mediaInfos = await albumListMediaInfos(IP, [4]); // astro のみ
+const url = fileDownloadUrl(IP, mediaInfos.data[0].filePath);
+```
+
+---
+
+## MediaType 一覧
+
+| 値 | 種別 | 説明 |
+|----|------|------|
+| 0 | PHOTO | 通常写真 |
+| 1 | VIDEO | 動画 |
+| 2 | PANORAMA | パノラマ |
+| 3 | TIMELAPSE | タイムラプス |
+| 4 | ASTRO | 天体 (ディープスカイ スタック画像) |
+| 5 | BURST | 連写 |
+| 6 | CONTINUOUS | 連続撮影 |
+| 7 | DARK_FRAME | ダークフレーム |
+| 8 | (不明) | 予約 |
+| 9 | (不明) | 予約 |
+
+---
+
+## デバイス情報
+
+### POST /deviceInfo
+
+デバイスの基本情報を取得します。
+
+**リクエスト:**
+```bash
+curl -X POST http://192.168.88.1:8082/deviceInfo \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+**レスポンス例:**
+```json
+{
+  "code": 0,
+  "data": {
+    "deviceID": 4,
+    "deviceName": "DWARF_mini_XXXXXX"
+  }
+}
+```
+
+**JavaScript:**
+```javascript
+const result = await getDeviceInfo("192.168.88.1");
+```
+
+---
+
+### POST /getDeviceActivateInfo
+
+デバイスのアクティベーション情報を取得します。
+
+**リクエスト:**
+```bash
+curl -X POST http://192.168.88.1:8082/getDeviceActivateInfo \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+**JavaScript:**
+```javascript
+const result = await getDeviceActivateInfo("192.168.88.1");
+```
+
+---
+
+### GET /getDefaultParamsConfig
+
+デフォルトのパラメータ設定を取得します。
+
+**リクエスト:**
+```bash
+curl http://192.168.88.1:8082/getDefaultParamsConfig
+```
+
+**JavaScript:**
+```javascript
+const result = await fetchDefaultParamsConfig("192.168.88.1");
+```
+
+---
+
+### GET /firmwareVersion
+
+ファームウェアバージョンを取得します。
+
+**リクエスト:**
+```bash
+curl http://192.168.88.1:8082/firmwareVersion
+```
+
+**JavaScript:**
+```javascript
+const result = await getFirmwareVersion("192.168.88.1");
+```
+
+---
+
+## 撮影モード
+
+### GET /shootingMode/getSupportedShootingModes
+
+対応している撮影モードの一覧を取得します。
+
+**リクエスト:**
+```bash
+curl http://192.168.88.1:8082/shootingMode/getSupportedShootingModes
+```
+
+**JavaScript:**
+```javascript
+const result = await getSupportedShootingModes("192.168.88.1");
+```
+
+---
+
+### POST /shootingMode/getParamAndSetting
+
+現在の撮影パラメータと設定を取得します。
+
+**リクエスト:**
+```bash
+curl -X POST http://192.168.88.1:8082/shootingMode/getParamAndSetting \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+**JavaScript:**
+```javascript
+const result = await getParamAndSetting("192.168.88.1");
+```
+
+---
+
+## アルバム管理
+
+### POST /album/list/mediaCounts
+
+メディアタイプ別のファイル数を取得します。
+
+**リクエスト:**
+```bash
+curl -X POST http://192.168.88.1:8082/album/list/mediaCounts \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+**レスポンス例:**
+```json
+{
+  "code": 0,
+  "data": [
+    { "count": 5, "mediaType": 0 },
+    { "count": 12, "mediaType": 4 }
+  ]
+}
+```
+
+**JavaScript:**
+```javascript
+const result = await albumListMediaCounts("192.168.88.1");
+for (const item of result.data) {
+  console.log(`mediaType=${item.mediaType}: ${item.count} 件`);
+}
+```
+
+---
+
+### POST /album/list/mediaInfos
+
+指定したメディアタイプの詳細情報を取得します。
+天体撮影の場合、`astroImageDetails` にRA/DEC、ターゲット名、撮影パラメータ等が含まれます。
+
+**リクエスト:**
+```bash
+curl -X POST http://192.168.88.1:8082/album/list/mediaInfos \
+  -H "Content-Type: application/json" \
+  -d '{"mediaTypeList": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'
+```
+
+**レスポンス例 (天体画像):**
+```json
+{
+  "code": 0,
+  "data": [
+    {
+      "mediaType": 4,
+      "fileName": "stacked_M31.jpg",
+      "filePath": "/DWARF_mini/Astronomy/2026-03-01_M31/stacked_M31.jpg",
+      "fileSize": 2048000,
+      "fileState": 0,
+      "thumbnailPath": "/DWARF_mini/Astronomy/2026-03-01_M31/thumb.jpg",
+      "modificationTime": 1740000000,
+      "camId": 1,
+      "astroTargetName": "M31",
+      "astroSubType": 0,
+      "astroImageDetails": {
+        "target": "M31",
+        "floatHourRa": 0.7123,
+        "floatDegreeDec": 41.2689,
+        "params": {
+          "binning": 0,
+          "exp": 15,
+          "filter": 0,
+          "format": 0,
+          "gain": 80,
+          "width": 1920,
+          "height": 1080
+        },
+        "shotsStacked": 120,
+        "shotsTaken": 130,
+        "shotsToTake": -1,
+        "srcDir": "/DWARF_mini/Astronomy/2026-03-01_M31/",
+        "totalExp": 1800,
+        "latitude": 35.6762,
+        "longitude": 139.6503,
+        "maxTemp": 25.3,
+        "minTemp": 22.1,
+        "folderSize": 5120000,
+        "annoInfo": null
+      }
+    }
+  ]
+}
+```
+
+**JavaScript:**
+```javascript
+// 天体画像のみ取得
+const result = await albumListMediaInfos("192.168.88.1", [4]);
+
+for (const media of result.data) {
+  const details = media.astroImageDetails;
+  if (details) {
+    console.log(`${details.target}: ${details.shotsStacked} フレーム積算`);
+    console.log(`  RA=${details.floatHourRa}h, DEC=${details.floatDegreeDec}°`);
+    console.log(`  露出=${details.params.exp}s, Gain=${details.params.gain}`);
+  }
+}
+```
+
+---
+
+### POST /album/astro/fitsList
+
+天体撮影セッションの FITS ファイル一覧を取得します。
+
+**リクエスト:**
+```bash
+curl -X POST http://192.168.88.1:8082/album/astro/fitsList \
+  -H "Content-Type: application/json" \
+  -d '{"srcDir": "/DWARF_mini/Astronomy/2026-03-01_M31/"}'
+```
+
+**レスポンス例:**
+```json
+{
+  "code": 0,
+  "data": {
+    "fitsInfo": [
+      {
+        "filePath": "/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits",
+        "isFailed": false,
+        "url": "/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits"
+      },
+      {
+        "filePath": "/DWARF_mini/Astronomy/2026-03-01_M31/frame_002.fits",
+        "isFailed": true,
+        "url": "/DWARF_mini/Astronomy/2026-03-01_M31/frame_002.fits"
+      }
+    ]
+  }
+}
+```
+
+**JavaScript:**
+```javascript
+const result = await albumAstroFitsList(
+  "192.168.88.1",
+  "/DWARF_mini/Astronomy/2026-03-01_M31/"
+);
+
+for (const fits of result.data.fitsInfo) {
+  const status = fits.isFailed ? "失敗" : "成功";
+  console.log(`${fits.filePath} [${status}]`);
+}
+```
+
+---
+
+### POST /album/delete
+
+メディアファイルを削除します。
+
+**リクエスト:**
+```bash
+curl -X POST http://192.168.88.1:8082/album/delete \
+  -H "Content-Type: application/json" \
+  -d '{
+    "datas": [
+      {
+        "mediaType": 4,
+        "fileName": "stacked_M31.jpg",
+        "subType": 0,
+        "filePath": "/DWARF_mini/Astronomy/2026-03-01_M31/stacked_M31.jpg"
+      }
+    ]
+  }'
+```
+
+**JavaScript:**
+```javascript
+await albumDelete("192.168.88.1", [
+  {
+    mediaType: 4,
+    fileName: "stacked_M31.jpg",
+    subType: 0,
+    filePath: "/DWARF_mini/Astronomy/2026-03-01_M31/stacked_M31.jpg",
+  },
+]);
+```
+
+---
+
+## ファイルダウンロード
+
+デバイス上のファイルは静的アセットとして配信されます。
+ファイルパスを直接 GET するだけでダウンロードできます。
+
+### URL の組み立て
+
+```javascript
+import { fileDownloadUrl, downloadFile } from "dwarfii_api/src/http_api.js";
+
+// URL を取得 (ブラウザで開く場合など)
+const url = fileDownloadUrl("192.168.88.1", "/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits");
+// => "http://192.168.88.1:8082/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits"
+```
+
+### curl でダウンロード
+
+```bash
+# FITS ファイルをダウンロード
+curl -o frame_001.fits \
+  http://192.168.88.1:8082/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits
+
+# サムネイルをダウンロード
+curl -o thumb.jpg \
+  http://192.168.88.1:8082/DWARF_mini/Astronomy/2026-03-01_M31/thumb.jpg
+```
+
+### JavaScript でダウンロード
+
+```javascript
+// Response オブジェクトを取得
+const response = await downloadFile(
+  "192.168.88.1",
+  "/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits"
+);
+
+// Node.js: ファイルに保存
+import { writeFile } from "node:fs/promises";
+const buffer = Buffer.from(await response.arrayBuffer());
+await writeFile("frame_001.fits", buffer);
+```
+
+### 全 FITS ファイルの一括ダウンロード
+
+```javascript
+import {
+  albumListMediaInfos,
+  albumAstroFitsList,
+  downloadFile,
+} from "dwarfii_api/src/http_api.js";
+import { writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+const IP = "192.168.88.1";
+
+// 1. 天体セッション一覧を取得
+const mediaInfos = await albumListMediaInfos(IP, [4]);
+
+for (const media of mediaInfos.data) {
+  const details = media.astroImageDetails;
+  if (!details) continue;
+
+  console.log(`セッション: ${details.target} (${details.srcDir})`);
+
+  // 2. FITS ファイル一覧を取得
+  const fitsResult = await albumAstroFitsList(IP, details.srcDir);
+
+  // 3. 成功フレームのみダウンロード
+  for (const fits of fitsResult.data.fitsInfo) {
+    if (fits.isFailed) continue;
+
+    const response = await downloadFile(IP, fits.filePath);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    await writeFile(basename(fits.filePath), buffer);
+    console.log(`  ダウンロード完了: ${basename(fits.filePath)}`);
+  }
+}
+```
+
+---
+
+## ストリーミング
+
+MJPEG ストリームは HTTP で直接取得できます。
+
+### メインストリーム (望遠カメラ)
+
+```javascript
+import { mainstreamUrl } from "dwarfii_api/src/http_api.js";
+
+const url = mainstreamUrl("192.168.88.1");
+// => "http://192.168.88.1:8082/mainstream"
+
+// HTML の <img> タグで表示可能
+// <img src="http://192.168.88.1:8082/mainstream" />
+```
+
+```bash
+# VLC で表示
+vlc http://192.168.88.1:8082/mainstream
+
+# ffmpeg で録画
+ffmpeg -i http://192.168.88.1:8082/mainstream -c copy output.mjpeg
+```
+
+### セカンドストリーム (広角カメラ)
+
+```javascript
+import { secondstreamUrl } from "dwarfii_api/src/http_api.js";
+
+const url = secondstreamUrl("192.168.88.1");
+// => "http://192.168.88.1:8082/secondstream"
+```
+
+```bash
+vlc http://192.168.88.1:8082/secondstream
+```
+
+> **注意:** DWARF II / 3 では従来ポート 8092 でストリーミングが提供されていましたが、
+> DWARF mini ではポート 8082 に統一されています。
+> 既存の `api_codes.js` の `telephotoURL` / `wideangleURL` (ポート 8092) と混同しないよう注意してください。

--- a/index.js
+++ b/index.js
@@ -18,4 +18,5 @@ export * from "./src/v3_focus.js";
 export * from "./src/v3_device_config.js";
 export * from "./src/v3_camera_params.js";
 export * from "./src/v3_schedule.js";
+export * from "./src/http_api.js";
 

--- a/src/http_api.d.ts
+++ b/src/http_api.d.ts
@@ -1,0 +1,201 @@
+/** @module http_api */
+
+// ---- Enum-like constants ----
+
+/**
+ * Known media type IDs returned by the album APIs.
+ * Discovered via pcap; not all values are confirmed.
+ */
+export declare const MediaType: {
+  /** Photo (standard camera shot) */
+  readonly PHOTO: 0;
+  /** Video */
+  readonly VIDEO: 1;
+  /** Panorama */
+  readonly PANORAMA: 2;
+  /** Time-lapse */
+  readonly TIMELAPSE: 3;
+  /** Astro (deep-sky stacked image) */
+  readonly ASTRO: 4;
+  /** Burst */
+  readonly BURST: 5;
+  /** Continuous shooting */
+  readonly CONTINUOUS: 6;
+  /** Dark frame */
+  readonly DARK_FRAME: 7;
+  /** Unknown / reserved */
+  readonly TYPE_8: 8;
+  /** Unknown / reserved */
+  readonly TYPE_9: 9;
+};
+
+// ---- Response types ----
+
+/** Single media-count entry returned by /album/list/mediaCounts */
+export interface MediaCount {
+  /** Number of items for this media type */
+  count: number;
+  /** Media type ID (see MediaType) */
+  mediaType: number;
+}
+
+/** Astro shooting parameters embedded in AstroImageDetails */
+export interface AstroParams {
+  /** Binning mode (0 = 1x1, 1 = 2x2) */
+  binning: number;
+  /** Exposure time in seconds */
+  exp: number;
+  /** Filter index */
+  filter: number;
+  /** File format (0 = FITS, 1 = TIFF) */
+  format: number;
+  /** Gain value */
+  gain: number;
+  /** Image width in pixels */
+  width: number;
+  /** Image height in pixels */
+  height: number;
+}
+
+/** Detailed astro image session information */
+export interface AstroImageDetails {
+  /** Target name (e.g. "M31", "Orion Nebula") */
+  target: string;
+  /** Right Ascension in decimal hours */
+  floatHourRa: number;
+  /** Declination in decimal degrees */
+  floatDegreeDec: number;
+  /** Shooting parameters */
+  params: AstroParams;
+  /** Number of frames successfully stacked */
+  shotsStacked: number;
+  /** Number of frames captured so far */
+  shotsTaken: number;
+  /** Requested number of frames (-1 = infinite) */
+  shotsToTake: number;
+  /** Session source directory on device */
+  srcDir: string;
+  /** Total exposure time in seconds */
+  totalExp: number;
+  /** Observation latitude */
+  latitude: number;
+  /** Observation longitude */
+  longitude: number;
+  /** Maximum sensor temperature during session (Celsius) */
+  maxTemp: number;
+  /** Minimum sensor temperature during session (Celsius) */
+  minTemp: number;
+  /** Total folder size in bytes */
+  folderSize: number;
+  /** Annotation / plate-solve info (may be null) */
+  annoInfo: unknown;
+}
+
+/** Single media item returned by /album/list/mediaInfos */
+export interface MediaInfo {
+  /** Media type ID */
+  mediaType: number;
+  /** File name */
+  fileName: string;
+  /** File path on device */
+  filePath: string;
+  /** File size in bytes */
+  fileSize: number;
+  /** File state (0 = normal) */
+  fileState: number;
+  /** Thumbnail image path on device */
+  thumbnailPath: string;
+  /** Last modification timestamp (epoch seconds) */
+  modificationTime: number;
+  /** Camera ID (1 = tele, 2 = wide) */
+  camId: number;
+  /** Astro target name (empty string for non-astro) */
+  astroTargetName: string;
+  /** Astro sub-type (0 for non-astro) */
+  astroSubType: number;
+  /** Detailed astro session info (null for non-astro media) */
+  astroImageDetails: AstroImageDetails | null;
+}
+
+/** Single FITS file entry returned by /album/astro/fitsList */
+export interface FitsFileInfo {
+  /** File path on device */
+  filePath: string;
+  /** Whether stacking of this frame failed */
+  isFailed: boolean;
+  /** Download URL path (relative to device base URL) */
+  url: string;
+}
+
+/** File descriptor for album deletion */
+export interface AlbumDeleteItem {
+  /** Media type ID */
+  mediaType: number;
+  /** File name */
+  fileName: string;
+  /** Sub-type */
+  subType: number;
+  /** File path on device */
+  filePath: string;
+}
+
+/** Generic API response wrapper */
+export interface ApiResponse<T = unknown> {
+  /** Response code (0 = success) */
+  code: number;
+  /** Response data */
+  data: T;
+}
+
+/** Response from /album/list/mediaCounts */
+export type MediaCountsResponse = ApiResponse<MediaCount[]>;
+
+/** Response from /album/list/mediaInfos */
+export type MediaInfosResponse = ApiResponse<MediaInfo[]>;
+
+/** Response from /album/astro/fitsList */
+export type FitsListResponse = ApiResponse<{ fitsInfo: FitsFileInfo[] }>;
+
+// ---- Function signatures ----
+
+// Streaming URLs
+export declare function mainstreamUrl(IP: string): string;
+export declare function secondstreamUrl(IP: string): string;
+
+// File download
+export declare function fileDownloadUrl(IP: string, filePath: string): string;
+export declare function downloadFile(
+  IP: string,
+  filePath: string
+): Promise<Response>;
+
+// Device info
+export declare function getDeviceInfo(IP: string): Promise<ApiResponse>;
+export declare function getDeviceActivateInfo(IP: string): Promise<ApiResponse>;
+export declare function fetchDefaultParamsConfig(
+  IP: string
+): Promise<ApiResponse>;
+export declare function getFirmwareVersion(IP: string): Promise<ApiResponse>;
+
+// Shooting mode
+export declare function getSupportedShootingModes(
+  IP: string
+): Promise<ApiResponse>;
+export declare function getParamAndSetting(IP: string): Promise<ApiResponse>;
+
+// Album management
+export declare function albumListMediaCounts(
+  IP: string
+): Promise<MediaCountsResponse>;
+export declare function albumListMediaInfos(
+  IP: string,
+  mediaTypeList?: number[]
+): Promise<MediaInfosResponse>;
+export declare function albumAstroFitsList(
+  IP: string,
+  srcDir: string
+): Promise<FitsListResponse>;
+export declare function albumDelete(
+  IP: string,
+  datas: AlbumDeleteItem[]
+): Promise<ApiResponse>;

--- a/src/http_api.js
+++ b/src/http_api.js
@@ -1,0 +1,295 @@
+/** @module http_api */
+// HTTP API wrapper for DWARF mini / II / 3 file download and album management.
+// All endpoints are served on port 8082 of the device.
+
+const DEFAULT_HTTP_PORT = 8082;
+
+/*** --------------------------------------------------------- ***/
+/*** ------------- URL BUILDERS ------------------------------ ***/
+/*** --------------------------------------------------------- ***/
+
+/**
+ * Build the base URL for the HTTP API.
+ * @param {string} IP - Device IP address
+ * @param {number} [port=8082] - HTTP port
+ * @returns {string}
+ */
+function baseUrl(IP, port = DEFAULT_HTTP_PORT) {
+  return `http://${IP}:${port}`;
+}
+
+/*** --------------------------------------------------------- ***/
+/*** ------------- STREAMING URLs ---------------------------- ***/
+/*** --------------------------------------------------------- ***/
+
+/**
+ * Get the mainstream (telephoto) MJPEG stream URL.
+ * @param {string} IP - Device IP address
+ * @returns {string}
+ */
+export function mainstreamUrl(IP) {
+  return `${baseUrl(IP)}/mainstream`;
+}
+
+/**
+ * Get the second stream (wide-angle) MJPEG stream URL.
+ * @param {string} IP - Device IP address
+ * @returns {string}
+ */
+export function secondstreamUrl(IP) {
+  return `${baseUrl(IP)}/secondstream`;
+}
+
+/*** --------------------------------------------------------- ***/
+/*** ------------- FILE DOWNLOAD ----------------------------- ***/
+/*** --------------------------------------------------------- ***/
+
+/**
+ * Build the full download URL for a file on the device.
+ * Files are served as static assets — just GET the returned URL.
+ * @param {string} IP - Device IP address
+ * @param {string} filePath - Absolute file path on device (e.g. "/DWARF_mini/Astronomy/.../xxx.fits")
+ * @returns {string}
+ */
+export function fileDownloadUrl(IP, filePath) {
+  return `${baseUrl(IP)}${filePath}`;
+}
+
+/**
+ * Download a file from the device.
+ * @param {string} IP - Device IP address
+ * @param {string} filePath - Absolute file path on device
+ * @returns {Promise<Response>}
+ */
+export async function downloadFile(IP, filePath) {
+  const url = fileDownloadUrl(IP, filePath);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `downloadFile failed: ${response.status} ${response.statusText} for ${url}`
+    );
+  }
+  return response;
+}
+
+/*** --------------------------------------------------------- ***/
+/*** ------------- DEVICE INFO ------------------------------- ***/
+/*** --------------------------------------------------------- ***/
+
+/**
+ * Get device information.
+ * POST /deviceInfo with empty body.
+ * Returns { code, data: { deviceID, deviceName, ... } }
+ * @param {string} IP - Device IP address
+ * @returns {Promise<Object>}
+ */
+export async function getDeviceInfo(IP) {
+  const url = `${baseUrl(IP)}/deviceInfo`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `getDeviceInfo failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Get device activation information.
+ * POST /getDeviceActivateInfo with empty body.
+ * @param {string} IP - Device IP address
+ * @returns {Promise<Object>}
+ */
+export async function getDeviceActivateInfo(IP) {
+  const url = `${baseUrl(IP)}/getDeviceActivateInfo`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `getDeviceActivateInfo failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Fetch default parameter configuration.
+ * GET /getDefaultParamsConfig
+ * Note: Named fetchDefaultParamsConfig to avoid conflict with the URL builder
+ * in api_codes.js which exports getDefaultParamsConfig.
+ * @param {string} IP - Device IP address
+ * @returns {Promise<Object>}
+ */
+export async function fetchDefaultParamsConfig(IP) {
+  const url = `${baseUrl(IP)}/getDefaultParamsConfig`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `getDefaultParamsConfig failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Get firmware version.
+ * GET /firmwareVersion
+ * @param {string} IP - Device IP address
+ * @returns {Promise<Object>}
+ */
+export async function getFirmwareVersion(IP) {
+  const url = `${baseUrl(IP)}/firmwareVersion`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `getFirmwareVersion failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/*** --------------------------------------------------------- ***/
+/*** ------------- SHOOTING MODE ----------------------------- ***/
+/*** --------------------------------------------------------- ***/
+
+/**
+ * Get supported shooting modes.
+ * GET /shootingMode/getSupportedShootingModes
+ * @param {string} IP - Device IP address
+ * @returns {Promise<Object>}
+ */
+export async function getSupportedShootingModes(IP) {
+  const url = `${baseUrl(IP)}/shootingMode/getSupportedShootingModes`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `getSupportedShootingModes failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Get current shooting parameters and settings.
+ * POST /shootingMode/getParamAndSetting with empty body.
+ * @param {string} IP - Device IP address
+ * @returns {Promise<Object>}
+ */
+export async function getParamAndSetting(IP) {
+  const url = `${baseUrl(IP)}/shootingMode/getParamAndSetting`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `getParamAndSetting failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/*** --------------------------------------------------------- ***/
+/*** ------------- ALBUM MANAGEMENT -------------------------- ***/
+/*** --------------------------------------------------------- ***/
+
+/**
+ * Get media counts per media type.
+ * POST /album/list/mediaCounts with empty body.
+ * Returns { code: 0, data: [{ count, mediaType }] }
+ * @param {string} IP - Device IP address
+ * @returns {Promise<Object>}
+ */
+export async function albumListMediaCounts(IP) {
+  const url = `${baseUrl(IP)}/album/list/mediaCounts`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `albumListMediaCounts failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Get detailed media information for given media types.
+ * POST /album/list/mediaInfos with mediaTypeList.
+ * Returns array of session objects with astroImageDetails (RA/DEC, target, params, etc.)
+ * @param {string} IP - Device IP address
+ * @param {number[]} [mediaTypeList=[0,1,2,3,4,5,6,7,8,9]] - Array of media type IDs to query
+ * @returns {Promise<Object>}
+ */
+export async function albumListMediaInfos(
+  IP,
+  mediaTypeList = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+) {
+  const url = `${baseUrl(IP)}/album/list/mediaInfos`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mediaTypeList }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `albumListMediaInfos failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Get the list of FITS files for an astro session directory.
+ * POST /album/astro/fitsList with srcDir.
+ * Returns { code: 0, data: { fitsInfo: [{ filePath, isFailed, url }] } }
+ * @param {string} IP - Device IP address
+ * @param {string} srcDir - Session directory path (e.g. "/DWARF_mini/Astronomy/{session}/")
+ * @returns {Promise<Object>}
+ */
+export async function albumAstroFitsList(IP, srcDir) {
+  const url = `${baseUrl(IP)}/album/astro/fitsList`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ srcDir }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `albumAstroFitsList failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Delete media files from the device.
+ * POST /album/delete with array of file descriptors.
+ * @param {string} IP - Device IP address
+ * @param {Array<{mediaType: number, fileName: string, subType: number, filePath: string}>} datas - Array of file descriptors to delete
+ * @returns {Promise<Object>}
+ */
+export async function albumDelete(IP, datas) {
+  const url = `${baseUrl(IP)}/album/delete`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ datas }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `albumDelete failed: ${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}

--- a/src/http_api.js
+++ b/src/http_api.js
@@ -1,6 +1,9 @@
 /** @module http_api */
 // HTTP API wrapper for DWARF mini / II / 3 file download and album management.
 // All endpoints are served on port 8082 of the device.
+//
+// Runtime requirement: global `fetch` (Node.js 18+ or browser).
+// For older Node.js runtimes, polyfill with `undici` or `node-fetch`.
 
 const DEFAULT_HTTP_PORT = 8082;
 
@@ -132,7 +135,7 @@ export async function fetchDefaultParamsConfig(IP) {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(
-      `getDefaultParamsConfig failed: ${response.status} ${response.statusText}`
+      `fetchDefaultParamsConfig failed: ${response.status} ${response.statusText}`
     );
   }
   return response.json();

--- a/tools/v3-probe/common.js
+++ b/tools/v3-probe/common.js
@@ -1,0 +1,244 @@
+// Shared configuration and utilities for v3-probe tools
+
+export const DEFAULT_IP = "192.168.88.1";
+export const DEFAULT_WS_PORT = 9900;
+export const DEFAULT_HTTP_PORT = 8082;
+export const DEFAULT_HTTPS_PORT = 8443;
+export const DEFAULT_CLIENT_ID = "0000DAF2-0000-1000-8000-00805F9B34FB";
+
+// V2 protocol version constants (from base.proto)
+export const WS_MAJOR_VERSION = 1;
+export const WS_MINOR_VERSION = 9;
+
+// V3 protocol version (discovered from DwarfLab app pcap 2026-02-28)
+export const V3_MAJOR_VERSION = 1;
+export const V3_MINOR_VERSION = 20;
+
+// Priority ports to scan first
+export const PRIORITY_PORTS = [9900, 9901, 8082, 8092, 443, 8443];
+
+// Known HTTP endpoints
+export const HTTP_ENDPOINTS = [
+  // Device info
+  { path: "/firmwareVersion", method: "GET" },
+  { path: "/getDefaultParamsConfig", method: "GET" },
+  { path: "/deviceInfo", method: "POST", body: {} },
+  { path: "/getDeviceActivateInfo", method: "POST", body: {} },
+  // Shooting mode
+  {
+    path: "/shootingMode/getSupportedShootingModes",
+    method: "GET",
+  },
+  {
+    path: "/shootingMode/getParamAndSetting",
+    method: "POST",
+    body: {},
+  },
+  // Album management
+  { path: "/album/list/mediaCounts", method: "POST", body: {} },
+  {
+    path: "/album/list/mediaInfos",
+    method: "POST",
+    body: { mediaTypeList: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] },
+  },
+  // Streaming (MJPEG — probe will just check HTTP status)
+  { path: "/mainstream", method: "GET" },
+  { path: "/secondstream", method: "GET" },
+];
+
+// CMD IDs for diagnostic commands (from protocol.proto DwarfCMD enum)
+export const CMD = {
+  // Camera Tele (mod=1)
+  TELE_OPEN_CAMERA: 10000,
+  TELE_CLOSE_CAMERA: 10001,
+  TELE_GET_EXP_MODE: 10008,
+  TELE_GET_EXP: 10010,
+  TELE_GET_GAIN_MODE: 10012,
+  TELE_GET_GAIN: 10014,
+  TELE_GET_BRIGHTNESS: 10016,
+  TELE_GET_CONTRAST: 10018,
+  TELE_GET_SATURATION: 10020,
+  TELE_GET_HUE: 10022,
+  TELE_GET_SHARPNESS: 10024,
+  TELE_GET_WB_MODE: 10026,
+  TELE_GET_WB_SCENE: 10028,
+  TELE_GET_WB_CT: 10030,
+  TELE_GET_IRCUT: 10032,
+  TELE_GET_ALL_PARAMS: 10036,
+  TELE_GET_ALL_FEATURE_PARAMS: 10038,
+  TELE_GET_SYSTEM_WORKING_STATE: 10039,
+
+  // Camera Wide (mod=2)
+  WIDE_OPEN_CAMERA: 12000,
+  WIDE_CLOSE_CAMERA: 12001,
+  WIDE_GET_EXP_MODE: 12003,
+  WIDE_GET_EXP: 12005,
+  WIDE_GET_GAIN: 12007,
+  WIDE_GET_BRIGHTNESS: 12009,
+  WIDE_GET_CONTRAST: 12011,
+  WIDE_GET_SATURATION: 12013,
+  WIDE_GET_HUE: 12015,
+  WIDE_GET_SHARPNESS: 12017,
+  WIDE_GET_WB_MODE: 12019,
+  WIDE_GET_WB_CT: 12021,
+  WIDE_GET_ALL_PARAMS: 12027,
+
+  // System (mod=4)
+  SYSTEM_SET_TIME: 13000,
+  SYSTEM_SET_MASTERLOCK: 13004,
+
+  // RGB Power (mod=5)
+  RGB_OPEN: 13500,
+  RGB_CLOSE: 13501,
+  RGB_POWERIND_ON: 13503,
+  RGB_POWERIND_OFF: 13504,
+
+  // Motor (mod=6)
+  MOTOR_GET_POSITION: 14011,
+
+  // Focus (mod=8)
+  FOCUS_AUTO: 15000,
+
+  // Notify (informational)
+  NOTIFY_BATTERY: 15201,
+  NOTIFY_CHARGE: 15202,
+  NOTIFY_SDCARD_INFO: 15203,
+  NOTIFY_RGB_STATE: 15221,
+  NOTIFY_HOST_SLAVE_MODE: 15223,
+  NOTIFY_TEMPERATURE: 15243,
+};
+
+// V3 commands discovered from DwarfLab app pcap (2026-02-28)
+// These commands are NOT in the V2 proto definitions
+export const V3_CMD = {
+  // Camera (replacements for V2 10000/12000)
+  TELE_OPEN: 10050,      // replaces 10000, arg 08 01 = open
+  WIDE_OPEN: 12036,      // replaces 12000, no arg or 08 01
+
+  // Astro (mod=3) — new query/config commands
+  ASTRO_11039: 11039,    // tracking/live stacking
+  ASTRO_11040: 11040,    // astro parameters (pipe-delimited config)
+  ASTRO_11043: 11043,    // exposure presets (called 3x with field2={0,1,2})
+
+  // System (mod=4) — new
+  SYSTEM_GPS: 13010,     // GPS/location (doubles: lat/lon/alt + string)
+
+  // Focus (mod=8) — new
+  FOCUS_INIT: 15011,     // focus initialization
+
+  // Shooting Schedule (mod=13)
+  SCHEDULE_16102: 16102,
+
+  // NEW mod=14 (device config/mode)
+  MOD14_MODE: 16404,     // mode switch
+  MOD14_CONFIG: 16405,   // device config (251B response with full specs)
+
+  // NEW mod=15 (unknown)
+  MOD15_16700: 16700,
+
+  // V3 notifications
+  NOTIFY_MOD14: 15261,
+  NOTIFY_MOD15: 15264,
+  NOTIFY_MODE_CHANGE: 15267,
+  NOTIFY_TEMP2: 15292,   // temperature variant
+};
+
+// Module IDs from protocol.proto
+export const MODULE = {
+  CAMERA_TELE: 1,   // 10000-10499
+  CAMERA_WIDE: 2,   // 12000-12499
+  ASTRO: 3,         // 11000-11499
+  SYSTEM: 4,        // 13000-13299
+  RGB_POWER: 5,     // 13500-13799
+  MOTOR: 6,         // 14000-14499
+  TRACK: 7,         // 14800-14899
+  FOCUS: 8,         // 15000-15099
+  NOTIFY: 9,        // 15200-15499
+  PANORAMA: 10,     // 15500-15599
+  SHOOTING_SCHEDULE: 13, // 16100-16300
+  MOD_14: 14,            // V3: device config/mode (16400-16499)
+  MOD_15: 15,            // V3: unknown (16700+)
+};
+
+// Message types
+export const MSG_TYPE = {
+  REQUEST: 0,
+  RESPONSE: 1,
+  NOTIFY: 2,
+  NOTIFY_RESPONSE: 3,
+};
+
+/**
+ * Parse common CLI arguments.
+ * @param {string[]} argv - process.argv
+ * @returns {{ ip: string, port: number, dryRun: boolean, verbose: boolean, help: boolean }}
+ */
+export function parseArgs(argv) {
+  const args = {
+    ip: DEFAULT_IP,
+    port: DEFAULT_WS_PORT,
+    dryRun: false,
+    verbose: false,
+    help: false,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--ip":
+        args.ip = argv[++i];
+        break;
+      case "--port":
+        args.port = parseInt(argv[++i], 10);
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--verbose":
+      case "-v":
+        args.verbose = true;
+        break;
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Format a timestamp for logging.
+ * @returns {string}
+ */
+export function timestamp() {
+  return new Date().toISOString();
+}
+
+/**
+ * Format bytes as hex string with spaces.
+ * @param {Buffer|Uint8Array} buf
+ * @param {number} [maxBytes=32]
+ * @returns {string}
+ */
+export function hexPreview(buf, maxBytes = 32) {
+  const slice = buf.slice(0, maxBytes);
+  const hex = Array.from(slice)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join(" ");
+  return buf.length > maxBytes ? `${hex} ... (${buf.length} bytes total)` : hex;
+}
+
+/**
+ * Colorized console output helpers.
+ */
+export const log = {
+  info: (msg) => console.log(`\x1b[36m[INFO]\x1b[0m ${msg}`),
+  ok: (msg) => console.log(`\x1b[32m[ OK ]\x1b[0m ${msg}`),
+  warn: (msg) => console.log(`\x1b[33m[WARN]\x1b[0m ${msg}`),
+  fail: (msg) => console.log(`\x1b[31m[FAIL]\x1b[0m ${msg}`),
+  data: (msg) => console.log(`\x1b[35m[DATA]\x1b[0m ${msg}`),
+  test: (name) => console.log(`\n\x1b[1;34m>>> Test ${name}\x1b[0m`),
+  section: (name) =>
+    console.log(`\n\x1b[1;33m${"=".repeat(60)}\n ${name}\n${"=".repeat(60)}\x1b[0m`),
+};


### PR DESCRIPTION
## Summary

- Add `src/http_api.js` with HTTP API wrapper functions for all DWARF mini endpoints on port 8082 (album management, file download, device info, shooting mode, streaming URLs)
- Add `src/http_api.d.ts` with TypeScript type definitions for all response types (`MediaCount`, `AstroImageDetails`, `MediaInfo`, `FitsFileInfo`, etc.)
- Add `docs/HTTP_API.md` with comprehensive Japanese API reference including curl and JavaScript examples
- Update `tools/v3-probe/common.js` with new HTTP endpoints for probe testing
- Re-export `http_api` module from `index.js`

## Details

All endpoints were discovered via pcap analysis of DWARF mini traffic:

**Album Management:**
- `albumListMediaCounts(IP)` — media file counts by type
- `albumListMediaInfos(IP, mediaTypeList)` — detailed session info with RA/DEC, target, params
- `albumAstroFitsList(IP, srcDir)` — FITS file listing for a session
- `albumDelete(IP, datas)` — delete media files

**File Download:**
- `fileDownloadUrl(IP, filePath)` — build download URL
- `downloadFile(IP, filePath)` — fetch file via HTTP GET

**Device Info:**
- `getDeviceInfo`, `getDeviceActivateInfo`, `fetchDefaultParamsConfig`, `getFirmwareVersion`

**Shooting Mode:**
- `getSupportedShootingModes`, `getParamAndSetting`

**Streaming:**
- `mainstreamUrl`, `secondstreamUrl` — MJPEG stream URLs on port 8082

Note: `fetchDefaultParamsConfig` is named to avoid export conflict with the existing `getDefaultParamsConfig` URL builder in `api_codes.js`.

Closes #6

## Test plan

- [ ] TypeScript typecheck passes (`npx tsc --noEmit`)
- [ ] ESLint passes (`npx eslint src/http_api.js`)
- [ ] Prettier passes (`npx prettier --check src/http_api.js src/http_api.d.ts`)
- [ ] Manual test: connect to DWARF mini and call `getDeviceInfo(IP)`
- [ ] Manual test: call `albumListMediaCounts(IP)` and verify response shape
- [ ] Manual test: call `albumListMediaInfos(IP, [4])` for astro images
- [ ] Manual test: download a FITS file via `downloadFile(IP, path)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)