### PR TITLE
fix: correct V3 proto definitions from pcap analysis

### DIFF
--- a/src/cmd_mapping.js
+++ b/src/cmd_mapping.js
@@ -374,7 +374,7 @@ export const responseMapping = {
   11036: "ComResponse", // V3: Save complete
   11039: "ComResponse", // V3: Status polling
   11040: "V3ResGetAstroParams", // V3: Get astro parameters
-  11041: "ComResponse", // V3: Set astro parameters
+  11041: "V3ResSetAstroParams", // V3: Set astro parameters
   11043: "V3ResGetExposurePresets", // V3: Get exposure presets
   11047: "ComResponse", // V3: Set observation location
   11048: "ComResponse", // V3: Confirm observation

--- a/src/proto/camera_params.proto
+++ b/src/proto/camera_params.proto
@@ -5,7 +5,8 @@ syntax = "proto3";
 // Set camera param: CMD 16700
 message V3ReqSetCameraParam {
     int64 param_id = 1;
-    int32 value = 2;
+    int32 flag = 2;
+    int32 value = 3;
 }
 
 // Set exposure/gain: CMD 16701

--- a/src/proto/v3_astro.proto
+++ b/src/proto/v3_astro.proto
@@ -29,7 +29,7 @@ message V3ReqGetAstroParams {
 
 message V3ResGetAstroParams {
     int32 code = 1;
-    V3AstroParamsData params = 2;
+    repeated V3AstroParamsData params = 2;
 }
 
 message V3AstroParamsData {
@@ -37,12 +37,18 @@ message V3AstroParamsData {
     int32 gain = 2;
     int32 total = 3;
     int32 count = 4;
-    string format = 5;
+    // field 5 (format) — not observed in pcap, reserved
+    string pipe_params = 6; // Pipe-delimited preset string e.g. "0|0|60|60|1|null"
 }
 
 // V3 Set astro parameters: CMD 11041
 message V3ReqSetAstroParams {
     string params = 1; // Pipe-delimited string e.g. "0|0|60|60|1|null"
+}
+
+message V3ResSetAstroParams {
+    int32 code = 1;
+    string pipe_params = 2; // Echo of accepted params
 }
 
 // V3 Get exposure presets: CMD 11043

--- a/src/proto/v3_astro.proto
+++ b/src/proto/v3_astro.proto
@@ -38,6 +38,8 @@ message V3AstroParamsData {
     int32 total = 3;
     int32 count = 4;
     // field 5 (format) — not observed in pcap, reserved
+    reserved 5;
+    reserved "format";
     string pipe_params = 6; // Pipe-delimited preset string e.g. "0|0|60|60|1|null"
 }
 

--- a/src/proto/v3_astro.proto
+++ b/src/proto/v3_astro.proto
@@ -29,6 +29,8 @@ message V3ReqGetAstroParams {
 
 message V3ResGetAstroParams {
     int32 code = 1;
+    // NOTE: `params` is intentionally `repeated`. In JS/TS this decodes as an array,
+    // so clients must iterate over `params[]` instead of treating it as a single object.
     repeated V3AstroParamsData params = 2;
 }
 

--- a/src/proto/v3_notify.proto
+++ b/src/proto/v3_notify.proto
@@ -34,8 +34,8 @@ message V3DeviceStatePath {
 // V3 Camera parameter state notification: CMD 15264
 message V3ResNotifyCameraParamState {
     int64 param_id = 1;
-    int32 value1 = 2;
-    int32 value2 = 3;
+    int32 flag = 2;  // 1 = manual mode (used in exp/gain notifications)
+    int32 value = 3; // Parameter value
 }
 
 // V3 Mode change notification: CMD 15267
@@ -45,12 +45,13 @@ message V3ResNotifyModeChange {
     int32 sub_mode = 3;
 }
 
-// V3 Stacking data notification: CMD 15270
+// V3 White balance notification: CMD 15270
+// Despite the message name, pcap analysis shows this carries WB color temperature data
 message V3ResNotifyStackingData {
     int32 field1 = 1;
-    int32 value = 2;
+    int32 color_temperature = 2; // White balance color temperature value
     int32 field3 = 3;
-    int32 flag = 4;
+    int32 camera = 4; // 0 = tele, 1 = wide
 }
 
 // V3 Photo state notification: CMD 15273

--- a/src/protobuf/protobuf.js
+++ b/src/protobuf/protobuf.js
@@ -14666,6 +14666,7 @@ $root.V3ReqSetCameraParam = (function () {
    * @exports IV3ReqSetCameraParam
    * @interface IV3ReqSetCameraParam
    * @property {number|Long|null} [paramId] V3ReqSetCameraParam paramId
+   * @property {number|null} [flag] V3ReqSetCameraParam flag
    * @property {number|null} [value] V3ReqSetCameraParam value
    */
 
@@ -14692,6 +14693,14 @@ $root.V3ReqSetCameraParam = (function () {
   V3ReqSetCameraParam.prototype.paramId = $util.Long
     ? $util.Long.fromBits(0, 0, false)
     : 0;
+
+  /**
+   * V3ReqSetCameraParam flag.
+   * @member {number} flag
+   * @memberof V3ReqSetCameraParam
+   * @instance
+   */
+  V3ReqSetCameraParam.prototype.flag = 0;
 
   /**
    * V3ReqSetCameraParam value.
@@ -14729,8 +14738,10 @@ $root.V3ReqSetCameraParam = (function () {
       Object.hasOwnProperty.call(message, "paramId")
     )
       writer.uint32(/* id 1, wireType 0 =*/ 8).int64(message.paramId);
+    if (message.flag != null && Object.hasOwnProperty.call(message, "flag"))
+      writer.uint32(/* id 2, wireType 0 =*/ 16).int32(message.flag);
     if (message.value != null && Object.hasOwnProperty.call(message, "value"))
-      writer.uint32(/* id 2, wireType 0 =*/ 16).int32(message.value);
+      writer.uint32(/* id 3, wireType 0 =*/ 24).int32(message.value);
     return writer;
   };
 
@@ -14773,6 +14784,10 @@ $root.V3ReqSetCameraParam = (function () {
           break;
         }
         case 2: {
+          message.flag = reader.int32();
+          break;
+        }
+        case 3: {
           message.value = reader.int32();
           break;
         }
@@ -14820,6 +14835,8 @@ $root.V3ReqSetCameraParam = (function () {
         )
       )
         return "paramId: integer|Long expected";
+    if (message.flag != null && message.hasOwnProperty("flag"))
+      if (!$util.isInteger(message.flag)) return "flag: integer expected";
     if (message.value != null && message.hasOwnProperty("value"))
       if (!$util.isInteger(message.value)) return "value: integer expected";
     return null;
@@ -14850,6 +14867,7 @@ $root.V3ReqSetCameraParam = (function () {
           object.paramId.low >>> 0,
           object.paramId.high >>> 0
         ).toNumber();
+    if (object.flag != null) message.flag = object.flag | 0;
     if (object.value != null) message.value = object.value | 0;
     return message;
   };
@@ -14876,6 +14894,7 @@ $root.V3ReqSetCameraParam = (function () {
             ? long.toNumber()
             : long;
       } else object.paramId = options.longs === String ? "0" : 0;
+      object.flag = 0;
       object.value = 0;
     }
     if (message.paramId != null && message.hasOwnProperty("paramId"))
@@ -14892,6 +14911,8 @@ $root.V3ReqSetCameraParam = (function () {
                 message.paramId.high >>> 0
               ).toNumber()
             : message.paramId;
+    if (message.flag != null && message.hasOwnProperty("flag"))
+      object.flag = message.flag;
     if (message.value != null && message.hasOwnProperty("value"))
       object.value = message.value;
     return object;
@@ -55088,7 +55109,7 @@ $root.V3ResGetAstroParams = (function () {
    * @exports IV3ResGetAstroParams
    * @interface IV3ResGetAstroParams
    * @property {number|null} [code] V3ResGetAstroParams code
-   * @property {IV3AstroParamsData|null} [params] V3ResGetAstroParams params
+   * @property {Array.<IV3AstroParamsData>|null} [params] V3ResGetAstroParams params
    */
 
   /**
@@ -55100,6 +55121,7 @@ $root.V3ResGetAstroParams = (function () {
    * @param {IV3ResGetAstroParams=} [properties] Properties to set
    */
   function V3ResGetAstroParams(properties) {
+    this.params = [];
     if (properties)
       for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
         if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
@@ -55115,11 +55137,11 @@ $root.V3ResGetAstroParams = (function () {
 
   /**
    * V3ResGetAstroParams params.
-   * @member {IV3AstroParamsData|null|undefined} params
+   * @member {Array.<IV3AstroParamsData>} params
    * @memberof V3ResGetAstroParams
    * @instance
    */
-  V3ResGetAstroParams.prototype.params = null;
+  V3ResGetAstroParams.prototype.params = $util.emptyArray;
 
   /**
    * Creates a new V3ResGetAstroParams instance using the specified properties.
@@ -55146,11 +55168,12 @@ $root.V3ResGetAstroParams = (function () {
     if (!writer) writer = $Writer.create();
     if (message.code != null && Object.hasOwnProperty.call(message, "code"))
       writer.uint32(/* id 1, wireType 0 =*/ 8).int32(message.code);
-    if (message.params != null && Object.hasOwnProperty.call(message, "params"))
-      $root.V3AstroParamsData.encode(
-        message.params,
-        writer.uint32(/* id 2, wireType 2 =*/ 18).fork()
-      ).ldelim();
+    if (message.params != null && message.params.length)
+      for (var i = 0; i < message.params.length; ++i)
+        $root.V3AstroParamsData.encode(
+          message.params[i],
+          writer.uint32(/* id 2, wireType 2 =*/ 18).fork()
+        ).ldelim();
     return writer;
   };
 
@@ -55193,9 +55216,9 @@ $root.V3ResGetAstroParams = (function () {
           break;
         }
         case 2: {
-          message.params = $root.V3AstroParamsData.decode(
-            reader,
-            reader.uint32()
+          if (!(message.params && message.params.length)) message.params = [];
+          message.params.push(
+            $root.V3AstroParamsData.decode(reader, reader.uint32())
           );
           break;
         }
@@ -55236,8 +55259,11 @@ $root.V3ResGetAstroParams = (function () {
     if (message.code != null && message.hasOwnProperty("code"))
       if (!$util.isInteger(message.code)) return "code: integer expected";
     if (message.params != null && message.hasOwnProperty("params")) {
-      var error = $root.V3AstroParamsData.verify(message.params);
-      if (error) return "params." + error;
+      if (!Array.isArray(message.params)) return "params: array expected";
+      for (var i = 0; i < message.params.length; ++i) {
+        var error = $root.V3AstroParamsData.verify(message.params[i]);
+        if (error) return "params." + error;
+      }
     }
     return null;
   };
@@ -55254,10 +55280,17 @@ $root.V3ResGetAstroParams = (function () {
     if (object instanceof $root.V3ResGetAstroParams) return object;
     var message = new $root.V3ResGetAstroParams();
     if (object.code != null) message.code = object.code | 0;
-    if (object.params != null) {
-      if (typeof object.params !== "object")
-        throw TypeError(".V3ResGetAstroParams.params: object expected");
-      message.params = $root.V3AstroParamsData.fromObject(object.params);
+    if (object.params) {
+      if (!Array.isArray(object.params))
+        throw TypeError(".V3ResGetAstroParams.params: array expected");
+      message.params = [];
+      for (var i = 0; i < object.params.length; ++i) {
+        if (typeof object.params[i] !== "object")
+          throw TypeError(".V3ResGetAstroParams.params: object expected");
+        message.params[i] = $root.V3AstroParamsData.fromObject(
+          object.params[i]
+        );
+      }
     }
     return message;
   };
@@ -55274,14 +55307,18 @@ $root.V3ResGetAstroParams = (function () {
   V3ResGetAstroParams.toObject = function toObject(message, options) {
     if (!options) options = {};
     var object = {};
-    if (options.defaults) {
-      object.code = 0;
-      object.params = null;
-    }
+    if (options.arrays || options.defaults) object.params = [];
+    if (options.defaults) object.code = 0;
     if (message.code != null && message.hasOwnProperty("code"))
       object.code = message.code;
-    if (message.params != null && message.hasOwnProperty("params"))
-      object.params = $root.V3AstroParamsData.toObject(message.params, options);
+    if (message.params && message.params.length) {
+      object.params = [];
+      for (var j = 0; j < message.params.length; ++j)
+        object.params[j] = $root.V3AstroParamsData.toObject(
+          message.params[j],
+          options
+        );
+    }
     return object;
   };
 
@@ -55323,7 +55360,7 @@ $root.V3AstroParamsData = (function () {
    * @property {number|null} [gain] V3AstroParamsData gain
    * @property {number|null} [total] V3AstroParamsData total
    * @property {number|null} [count] V3AstroParamsData count
-   * @property {string|null} [format] V3AstroParamsData format
+   * @property {string|null} [pipeParams] V3AstroParamsData pipeParams
    */
 
   /**
@@ -55373,12 +55410,12 @@ $root.V3AstroParamsData = (function () {
   V3AstroParamsData.prototype.count = 0;
 
   /**
-   * V3AstroParamsData format.
-   * @member {string} format
+   * V3AstroParamsData pipeParams.
+   * @member {string} pipeParams
    * @memberof V3AstroParamsData
    * @instance
    */
-  V3AstroParamsData.prototype.format = "";
+  V3AstroParamsData.prototype.pipeParams = "";
 
   /**
    * Creates a new V3AstroParamsData instance using the specified properties.
@@ -55414,8 +55451,11 @@ $root.V3AstroParamsData = (function () {
       writer.uint32(/* id 3, wireType 0 =*/ 24).int32(message.total);
     if (message.count != null && Object.hasOwnProperty.call(message, "count"))
       writer.uint32(/* id 4, wireType 0 =*/ 32).int32(message.count);
-    if (message.format != null && Object.hasOwnProperty.call(message, "format"))
-      writer.uint32(/* id 5, wireType 2 =*/ 42).string(message.format);
+    if (
+      message.pipeParams != null &&
+      Object.hasOwnProperty.call(message, "pipeParams")
+    )
+      writer.uint32(/* id 6, wireType 2 =*/ 50).string(message.pipeParams);
     return writer;
   };
 
@@ -55469,8 +55509,8 @@ $root.V3AstroParamsData = (function () {
           message.count = reader.int32();
           break;
         }
-        case 5: {
-          message.format = reader.string();
+        case 6: {
+          message.pipeParams = reader.string();
           break;
         }
         default:
@@ -55515,8 +55555,9 @@ $root.V3AstroParamsData = (function () {
       if (!$util.isInteger(message.total)) return "total: integer expected";
     if (message.count != null && message.hasOwnProperty("count"))
       if (!$util.isInteger(message.count)) return "count: integer expected";
-    if (message.format != null && message.hasOwnProperty("format"))
-      if (!$util.isString(message.format)) return "format: string expected";
+    if (message.pipeParams != null && message.hasOwnProperty("pipeParams"))
+      if (!$util.isString(message.pipeParams))
+        return "pipeParams: string expected";
     return null;
   };
 
@@ -55535,7 +55576,8 @@ $root.V3AstroParamsData = (function () {
     if (object.gain != null) message.gain = object.gain | 0;
     if (object.total != null) message.total = object.total | 0;
     if (object.count != null) message.count = object.count | 0;
-    if (object.format != null) message.format = String(object.format);
+    if (object.pipeParams != null)
+      message.pipeParams = String(object.pipeParams);
     return message;
   };
 
@@ -55556,7 +55598,7 @@ $root.V3AstroParamsData = (function () {
       object.gain = 0;
       object.total = 0;
       object.count = 0;
-      object.format = "";
+      object.pipeParams = "";
     }
     if (message.exposure != null && message.hasOwnProperty("exposure"))
       object.exposure = message.exposure;
@@ -55566,8 +55608,8 @@ $root.V3AstroParamsData = (function () {
       object.total = message.total;
     if (message.count != null && message.hasOwnProperty("count"))
       object.count = message.count;
-    if (message.format != null && message.hasOwnProperty("format"))
-      object.format = message.format;
+    if (message.pipeParams != null && message.hasOwnProperty("pipeParams"))
+      object.pipeParams = message.pipeParams;
     return object;
   };
 
@@ -55795,6 +55837,231 @@ $root.V3ReqSetAstroParams = (function () {
   };
 
   return V3ReqSetAstroParams;
+})();
+
+$root.V3ResSetAstroParams = (function () {
+  /**
+   * Properties of a V3ResSetAstroParams.
+   * @exports IV3ResSetAstroParams
+   * @interface IV3ResSetAstroParams
+   * @property {number|null} [code] V3ResSetAstroParams code
+   * @property {string|null} [pipeParams] V3ResSetAstroParams pipeParams
+   */
+
+  /**
+   * Constructs a new V3ResSetAstroParams.
+   * @exports V3ResSetAstroParams
+   * @classdesc Represents a V3ResSetAstroParams.
+   * @implements IV3ResSetAstroParams
+   * @constructor
+   * @param {IV3ResSetAstroParams=} [properties] Properties to set
+   */
+  function V3ResSetAstroParams(properties) {
+    if (properties)
+      for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+        if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
+  }
+
+  /**
+   * V3ResSetAstroParams code.
+   * @member {number} code
+   * @memberof V3ResSetAstroParams
+   * @instance
+   */
+  V3ResSetAstroParams.prototype.code = 0;
+
+  /**
+   * V3ResSetAstroParams pipeParams.
+   * @member {string} pipeParams
+   * @memberof V3ResSetAstroParams
+   * @instance
+   */
+  V3ResSetAstroParams.prototype.pipeParams = "";
+
+  /**
+   * Creates a new V3ResSetAstroParams instance using the specified properties.
+   * @function create
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {IV3ResSetAstroParams=} [properties] Properties to set
+   * @returns {V3ResSetAstroParams} V3ResSetAstroParams instance
+   */
+  V3ResSetAstroParams.create = function create(properties) {
+    return new V3ResSetAstroParams(properties);
+  };
+
+  /**
+   * Encodes the specified V3ResSetAstroParams message. Does not implicitly {@link V3ResSetAstroParams.verify|verify} messages.
+   * @function encode
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {IV3ResSetAstroParams} message V3ResSetAstroParams message or plain object to encode
+   * @param {$protobuf.Writer} [writer] Writer to encode to
+   * @returns {$protobuf.Writer} Writer
+   */
+  V3ResSetAstroParams.encode = function encode(message, writer) {
+    if (!writer) writer = $Writer.create();
+    if (message.code != null && Object.hasOwnProperty.call(message, "code"))
+      writer.uint32(/* id 1, wireType 0 =*/ 8).int32(message.code);
+    if (
+      message.pipeParams != null &&
+      Object.hasOwnProperty.call(message, "pipeParams")
+    )
+      writer.uint32(/* id 2, wireType 2 =*/ 18).string(message.pipeParams);
+    return writer;
+  };
+
+  /**
+   * Encodes the specified V3ResSetAstroParams message, length delimited. Does not implicitly {@link V3ResSetAstroParams.verify|verify} messages.
+   * @function encodeDelimited
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {IV3ResSetAstroParams} message V3ResSetAstroParams message or plain object to encode
+   * @param {$protobuf.Writer} [writer] Writer to encode to
+   * @returns {$protobuf.Writer} Writer
+   */
+  V3ResSetAstroParams.encodeDelimited = function encodeDelimited(
+    message,
+    writer
+  ) {
+    return this.encode(message, writer).ldelim();
+  };
+
+  /**
+   * Decodes a V3ResSetAstroParams message from the specified reader or buffer.
+   * @function decode
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+   * @param {number} [length] Message length if known beforehand
+   * @returns {V3ResSetAstroParams} V3ResSetAstroParams
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  V3ResSetAstroParams.decode = function decode(reader, length) {
+    if (!(reader instanceof $Reader)) reader = $Reader.create(reader);
+    var end = length === undefined ? reader.len : reader.pos + length,
+      message = new $root.V3ResSetAstroParams();
+    while (reader.pos < end) {
+      var tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          message.code = reader.int32();
+          break;
+        }
+        case 2: {
+          message.pipeParams = reader.string();
+          break;
+        }
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  };
+
+  /**
+   * Decodes a V3ResSetAstroParams message from the specified reader or buffer, length delimited.
+   * @function decodeDelimited
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+   * @returns {V3ResSetAstroParams} V3ResSetAstroParams
+   * @throws {Error} If the payload is not a reader or valid buffer
+   * @throws {$protobuf.util.ProtocolError} If required fields are missing
+   */
+  V3ResSetAstroParams.decodeDelimited = function decodeDelimited(reader) {
+    if (!(reader instanceof $Reader)) reader = new $Reader(reader);
+    return this.decode(reader, reader.uint32());
+  };
+
+  /**
+   * Verifies a V3ResSetAstroParams message.
+   * @function verify
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {Object.<string,*>} message Plain object to verify
+   * @returns {string|null} `null` if valid, otherwise the reason why it is not
+   */
+  V3ResSetAstroParams.verify = function verify(message) {
+    if (typeof message !== "object" || message === null)
+      return "object expected";
+    if (message.code != null && message.hasOwnProperty("code"))
+      if (!$util.isInteger(message.code)) return "code: integer expected";
+    if (message.pipeParams != null && message.hasOwnProperty("pipeParams"))
+      if (!$util.isString(message.pipeParams))
+        return "pipeParams: string expected";
+    return null;
+  };
+
+  /**
+   * Creates a V3ResSetAstroParams message from a plain object. Also converts values to their respective internal types.
+   * @function fromObject
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {Object.<string,*>} object Plain object
+   * @returns {V3ResSetAstroParams} V3ResSetAstroParams
+   */
+  V3ResSetAstroParams.fromObject = function fromObject(object) {
+    if (object instanceof $root.V3ResSetAstroParams) return object;
+    var message = new $root.V3ResSetAstroParams();
+    if (object.code != null) message.code = object.code | 0;
+    if (object.pipeParams != null)
+      message.pipeParams = String(object.pipeParams);
+    return message;
+  };
+
+  /**
+   * Creates a plain object from a V3ResSetAstroParams message. Also converts values to other types if specified.
+   * @function toObject
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {V3ResSetAstroParams} message V3ResSetAstroParams
+   * @param {$protobuf.IConversionOptions} [options] Conversion options
+   * @returns {Object.<string,*>} Plain object
+   */
+  V3ResSetAstroParams.toObject = function toObject(message, options) {
+    if (!options) options = {};
+    var object = {};
+    if (options.defaults) {
+      object.code = 0;
+      object.pipeParams = "";
+    }
+    if (message.code != null && message.hasOwnProperty("code"))
+      object.code = message.code;
+    if (message.pipeParams != null && message.hasOwnProperty("pipeParams"))
+      object.pipeParams = message.pipeParams;
+    return object;
+  };
+
+  /**
+   * Converts this V3ResSetAstroParams to JSON.
+   * @function toJSON
+   * @memberof V3ResSetAstroParams
+   * @instance
+   * @returns {Object.<string,*>} JSON object
+   */
+  V3ResSetAstroParams.prototype.toJSON = function toJSON() {
+    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+  };
+
+  /**
+   * Gets the default type url for V3ResSetAstroParams
+   * @function getTypeUrl
+   * @memberof V3ResSetAstroParams
+   * @static
+   * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+   * @returns {string} The default type url
+   */
+  V3ResSetAstroParams.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+    if (typeUrlPrefix === undefined) {
+      typeUrlPrefix = "type.googleapis.com";
+    }
+    return typeUrlPrefix + "/V3ResSetAstroParams";
+  };
+
+  return V3ResSetAstroParams;
 })();
 
 $root.V3ReqGetExposurePresets = (function () {
@@ -59064,8 +59331,8 @@ $root.V3ResNotifyCameraParamState = (function () {
    * @exports IV3ResNotifyCameraParamState
    * @interface IV3ResNotifyCameraParamState
    * @property {number|Long|null} [paramId] V3ResNotifyCameraParamState paramId
-   * @property {number|null} [value1] V3ResNotifyCameraParamState value1
-   * @property {number|null} [value2] V3ResNotifyCameraParamState value2
+   * @property {number|null} [flag] V3ResNotifyCameraParamState flag
+   * @property {number|null} [value] V3ResNotifyCameraParamState value
    */
 
   /**
@@ -59093,20 +59360,20 @@ $root.V3ResNotifyCameraParamState = (function () {
     : 0;
 
   /**
-   * V3ResNotifyCameraParamState value1.
-   * @member {number} value1
+   * V3ResNotifyCameraParamState flag.
+   * @member {number} flag
    * @memberof V3ResNotifyCameraParamState
    * @instance
    */
-  V3ResNotifyCameraParamState.prototype.value1 = 0;
+  V3ResNotifyCameraParamState.prototype.flag = 0;
 
   /**
-   * V3ResNotifyCameraParamState value2.
-   * @member {number} value2
+   * V3ResNotifyCameraParamState value.
+   * @member {number} value
    * @memberof V3ResNotifyCameraParamState
    * @instance
    */
-  V3ResNotifyCameraParamState.prototype.value2 = 0;
+  V3ResNotifyCameraParamState.prototype.value = 0;
 
   /**
    * Creates a new V3ResNotifyCameraParamState instance using the specified properties.
@@ -59136,10 +59403,10 @@ $root.V3ResNotifyCameraParamState = (function () {
       Object.hasOwnProperty.call(message, "paramId")
     )
       writer.uint32(/* id 1, wireType 0 =*/ 8).int64(message.paramId);
-    if (message.value1 != null && Object.hasOwnProperty.call(message, "value1"))
-      writer.uint32(/* id 2, wireType 0 =*/ 16).int32(message.value1);
-    if (message.value2 != null && Object.hasOwnProperty.call(message, "value2"))
-      writer.uint32(/* id 3, wireType 0 =*/ 24).int32(message.value2);
+    if (message.flag != null && Object.hasOwnProperty.call(message, "flag"))
+      writer.uint32(/* id 2, wireType 0 =*/ 16).int32(message.flag);
+    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+      writer.uint32(/* id 3, wireType 0 =*/ 24).int32(message.value);
     return writer;
   };
 
@@ -59182,11 +59449,11 @@ $root.V3ResNotifyCameraParamState = (function () {
           break;
         }
         case 2: {
-          message.value1 = reader.int32();
+          message.flag = reader.int32();
           break;
         }
         case 3: {
-          message.value2 = reader.int32();
+          message.value = reader.int32();
           break;
         }
         default:
@@ -59235,10 +59502,10 @@ $root.V3ResNotifyCameraParamState = (function () {
         )
       )
         return "paramId: integer|Long expected";
-    if (message.value1 != null && message.hasOwnProperty("value1"))
-      if (!$util.isInteger(message.value1)) return "value1: integer expected";
-    if (message.value2 != null && message.hasOwnProperty("value2"))
-      if (!$util.isInteger(message.value2)) return "value2: integer expected";
+    if (message.flag != null && message.hasOwnProperty("flag"))
+      if (!$util.isInteger(message.flag)) return "flag: integer expected";
+    if (message.value != null && message.hasOwnProperty("value"))
+      if (!$util.isInteger(message.value)) return "value: integer expected";
     return null;
   };
 
@@ -59267,8 +59534,8 @@ $root.V3ResNotifyCameraParamState = (function () {
           object.paramId.low >>> 0,
           object.paramId.high >>> 0
         ).toNumber();
-    if (object.value1 != null) message.value1 = object.value1 | 0;
-    if (object.value2 != null) message.value2 = object.value2 | 0;
+    if (object.flag != null) message.flag = object.flag | 0;
+    if (object.value != null) message.value = object.value | 0;
     return message;
   };
 
@@ -59294,8 +59561,8 @@ $root.V3ResNotifyCameraParamState = (function () {
             ? long.toNumber()
             : long;
       } else object.paramId = options.longs === String ? "0" : 0;
-      object.value1 = 0;
-      object.value2 = 0;
+      object.flag = 0;
+      object.value = 0;
     }
     if (message.paramId != null && message.hasOwnProperty("paramId"))
       if (typeof message.paramId === "number")
@@ -59311,10 +59578,10 @@ $root.V3ResNotifyCameraParamState = (function () {
                 message.paramId.high >>> 0
               ).toNumber()
             : message.paramId;
-    if (message.value1 != null && message.hasOwnProperty("value1"))
-      object.value1 = message.value1;
-    if (message.value2 != null && message.hasOwnProperty("value2"))
-      object.value2 = message.value2;
+    if (message.flag != null && message.hasOwnProperty("flag"))
+      object.flag = message.flag;
+    if (message.value != null && message.hasOwnProperty("value"))
+      object.value = message.value;
     return object;
   };
 
@@ -59601,9 +59868,9 @@ $root.V3ResNotifyStackingData = (function () {
    * @exports IV3ResNotifyStackingData
    * @interface IV3ResNotifyStackingData
    * @property {number|null} [field1] V3ResNotifyStackingData field1
-   * @property {number|null} [value] V3ResNotifyStackingData value
+   * @property {number|null} [colorTemperature] V3ResNotifyStackingData colorTemperature
    * @property {number|null} [field3] V3ResNotifyStackingData field3
-   * @property {number|null} [flag] V3ResNotifyStackingData flag
+   * @property {number|null} [camera] V3ResNotifyStackingData camera
    */
 
   /**
@@ -59629,12 +59896,12 @@ $root.V3ResNotifyStackingData = (function () {
   V3ResNotifyStackingData.prototype.field1 = 0;
 
   /**
-   * V3ResNotifyStackingData value.
-   * @member {number} value
+   * V3ResNotifyStackingData colorTemperature.
+   * @member {number} colorTemperature
    * @memberof V3ResNotifyStackingData
    * @instance
    */
-  V3ResNotifyStackingData.prototype.value = 0;
+  V3ResNotifyStackingData.prototype.colorTemperature = 0;
 
   /**
    * V3ResNotifyStackingData field3.
@@ -59645,12 +59912,12 @@ $root.V3ResNotifyStackingData = (function () {
   V3ResNotifyStackingData.prototype.field3 = 0;
 
   /**
-   * V3ResNotifyStackingData flag.
-   * @member {number} flag
+   * V3ResNotifyStackingData camera.
+   * @member {number} camera
    * @memberof V3ResNotifyStackingData
    * @instance
    */
-  V3ResNotifyStackingData.prototype.flag = 0;
+  V3ResNotifyStackingData.prototype.camera = 0;
 
   /**
    * Creates a new V3ResNotifyStackingData instance using the specified properties.
@@ -59677,12 +59944,15 @@ $root.V3ResNotifyStackingData = (function () {
     if (!writer) writer = $Writer.create();
     if (message.field1 != null && Object.hasOwnProperty.call(message, "field1"))
       writer.uint32(/* id 1, wireType 0 =*/ 8).int32(message.field1);
-    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
-      writer.uint32(/* id 2, wireType 0 =*/ 16).int32(message.value);
+    if (
+      message.colorTemperature != null &&
+      Object.hasOwnProperty.call(message, "colorTemperature")
+    )
+      writer.uint32(/* id 2, wireType 0 =*/ 16).int32(message.colorTemperature);
     if (message.field3 != null && Object.hasOwnProperty.call(message, "field3"))
       writer.uint32(/* id 3, wireType 0 =*/ 24).int32(message.field3);
-    if (message.flag != null && Object.hasOwnProperty.call(message, "flag"))
-      writer.uint32(/* id 4, wireType 0 =*/ 32).int32(message.flag);
+    if (message.camera != null && Object.hasOwnProperty.call(message, "camera"))
+      writer.uint32(/* id 4, wireType 0 =*/ 32).int32(message.camera);
     return writer;
   };
 
@@ -59725,7 +59995,7 @@ $root.V3ResNotifyStackingData = (function () {
           break;
         }
         case 2: {
-          message.value = reader.int32();
+          message.colorTemperature = reader.int32();
           break;
         }
         case 3: {
@@ -59733,7 +60003,7 @@ $root.V3ResNotifyStackingData = (function () {
           break;
         }
         case 4: {
-          message.flag = reader.int32();
+          message.camera = reader.int32();
           break;
         }
         default:
@@ -59772,12 +60042,16 @@ $root.V3ResNotifyStackingData = (function () {
       return "object expected";
     if (message.field1 != null && message.hasOwnProperty("field1"))
       if (!$util.isInteger(message.field1)) return "field1: integer expected";
-    if (message.value != null && message.hasOwnProperty("value"))
-      if (!$util.isInteger(message.value)) return "value: integer expected";
+    if (
+      message.colorTemperature != null &&
+      message.hasOwnProperty("colorTemperature")
+    )
+      if (!$util.isInteger(message.colorTemperature))
+        return "colorTemperature: integer expected";
     if (message.field3 != null && message.hasOwnProperty("field3"))
       if (!$util.isInteger(message.field3)) return "field3: integer expected";
-    if (message.flag != null && message.hasOwnProperty("flag"))
-      if (!$util.isInteger(message.flag)) return "flag: integer expected";
+    if (message.camera != null && message.hasOwnProperty("camera"))
+      if (!$util.isInteger(message.camera)) return "camera: integer expected";
     return null;
   };
 
@@ -59793,9 +60067,10 @@ $root.V3ResNotifyStackingData = (function () {
     if (object instanceof $root.V3ResNotifyStackingData) return object;
     var message = new $root.V3ResNotifyStackingData();
     if (object.field1 != null) message.field1 = object.field1 | 0;
-    if (object.value != null) message.value = object.value | 0;
+    if (object.colorTemperature != null)
+      message.colorTemperature = object.colorTemperature | 0;
     if (object.field3 != null) message.field3 = object.field3 | 0;
-    if (object.flag != null) message.flag = object.flag | 0;
+    if (object.camera != null) message.camera = object.camera | 0;
     return message;
   };
 
@@ -59813,18 +60088,21 @@ $root.V3ResNotifyStackingData = (function () {
     var object = {};
     if (options.defaults) {
       object.field1 = 0;
-      object.value = 0;
+      object.colorTemperature = 0;
       object.field3 = 0;
-      object.flag = 0;
+      object.camera = 0;
     }
     if (message.field1 != null && message.hasOwnProperty("field1"))
       object.field1 = message.field1;
-    if (message.value != null && message.hasOwnProperty("value"))
-      object.value = message.value;
+    if (
+      message.colorTemperature != null &&
+      message.hasOwnProperty("colorTemperature")
+    )
+      object.colorTemperature = message.colorTemperature;
     if (message.field3 != null && message.hasOwnProperty("field3"))
       object.field3 = message.field3;
-    if (message.flag != null && message.hasOwnProperty("flag"))
-      object.flag = message.flag;
+    if (message.camera != null && message.hasOwnProperty("camera"))
+      object.camera = message.camera;
     return object;
   };
 

--- a/src/v3_astro.js
+++ b/src/v3_astro.js
@@ -102,13 +102,7 @@ export function messageV3AstroGotoDSO(ra, dec, targetName, lon, lat, mode = 2) {
  * @param {number} mode - Mode (default 8)
  * @returns {Uint8Array}
  */
-export function messageV3AstroGotoSolar(
-  index,
-  lon,
-  lat,
-  targetName,
-  mode = 8
-) {
+export function messageV3AstroGotoSolar(index, lon, lat, targetName, mode = 8) {
   let module_id = Dwarfii_Api.ModuleId.MODULE_ASTRO;
   let interface_id =
     Dwarfii_Api.DwarfCMD.CMD_ASTRO_START_ONE_CLICK_GOTO_SOLAR_SYSTEM;
@@ -212,7 +206,12 @@ export function messageV3AstroStatusPolling(
 }
 /**
  * V3: Get astro parameters
- * Create Encoded Packet for the command CMD_V3_ASTRO_GET_PARAMS
+ * Create Encoded Packet for the command CMD_V3_ASTRO_GET_PARAMS (11040)
+ *
+ * Response contains repeated V3AstroParamsData, each with a pipe_params field
+ * in the format: "exposure|gain|total|count|binning|format"
+ * e.g. "0|0|60|60|1|null"
+ *
  * @param {number} mode - Mode (0 or 1)
  * @returns {Uint8Array}
  */
@@ -230,7 +229,13 @@ export function messageV3AstroGetParams(mode = 0) {
 }
 /**
  * V3: Set astro parameters
- * Create Encoded Packet for the command CMD_V3_ASTRO_SET_PARAMS
+ * Create Encoded Packet for the command CMD_V3_ASTRO_SET_PARAMS (11041)
+ *
+ * The params string is pipe-delimited: "exposure|gain|total|count|binning|format"
+ * e.g. "0|0|60|60|1|null"
+ *
+ * Response is V3ResSetAstroParams with code and pipe_params echo.
+ *
  * @param {string} params - Pipe-delimited parameter string e.g. "0|0|60|60|1|null"
  * @returns {Uint8Array}
  */

--- a/src/v3_astro.js
+++ b/src/v3_astro.js
@@ -208,7 +208,7 @@ export function messageV3AstroStatusPolling(
  * V3: Get astro parameters
  * Create Encoded Packet for the command CMD_V3_ASTRO_GET_PARAMS (11040)
  *
- * Response contains repeated V3AstroParamsData, each with a pipe_params field
+ * Response contains repeated V3AstroParamsData, each with a pipeParams field
  * in the format: "exposure|gain|total|count|binning|format"
  * e.g. "0|0|60|60|1|null"
  *
@@ -234,7 +234,7 @@ export function messageV3AstroGetParams(mode = 0) {
  * The params string is pipe-delimited: "exposure|gain|total|count|binning|format"
  * e.g. "0|0|60|60|1|null"
  *
- * Response is V3ResSetAstroParams with code and pipe_params echo.
+ * Response is V3ResSetAstroParams with code and pipeParams echo.
  *
  * @param {string} params - Pipe-delimited parameter string e.g. "0|0|60|60|1|null"
  * @returns {Uint8Array}

--- a/src/v3_camera_params.js
+++ b/src/v3_camera_params.js
@@ -9,10 +9,58 @@ import { cmdMapping } from "./cmd_mapping.js";
 /*** -------- V3 MODULE CAMERA PARAMS (16700+) --------------- ***/
 /*** --------------------------------------------------------- ***/
 /**
- * V3: Adjust camera parameter
- * Create Encoded Packet for the command CMD_V3_CAMERA_PARAMS_ADJUST
- * @param {number} paramId - Parameter ID (large varint from HTTP API)
+ * V3: Set camera parameter (general)
+ * Create Encoded Packet for the command CMD_V3_CAMERA_PARAMS_SET_PARAM (16700)
+ * @param {number} paramId - Parameter ID (encoded via encodeParamId)
  * @param {number} value - Parameter value
+ * @param {number} [flag=0] - Flag (0 = auto, 1 = manual; used for some params)
+ * @returns {Uint8Array}
+ */
+export function messageV3CameraParamSet(paramId, value, flag = 0) {
+  let module_id = Dwarfii_Api.ModuleId.MODULE_CAMERA_PARAMS;
+  let interface_id = Dwarfii_Api.DwarfCMD.CMD_V3_CAMERA_PARAMS_SET_PARAM;
+  let type_id = Dwarfii_Api.MessageTypeId.TYPE_REQUEST;
+  const cmdClass = cmdMapping[interface_id];
+  let class_message = Dwarfii_Api[cmdClass];
+  let message = class_message.create({
+    paramId: paramId,
+    flag: flag,
+    value: value,
+  });
+  console.log(
+    `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
+  );
+  return createPacket(message, class_message, module_id, interface_id, type_id);
+}
+/**
+ * V3: Set exposure/gain parameter
+ * Create Encoded Packet for the command CMD_V3_CAMERA_PARAMS_SET_EXP_GAIN (16701)
+ * @param {number} paramId - Parameter ID (encoded via encodeParamId)
+ * @param {number} value - Exposure or gain value
+ * @param {number} [flag=1] - Flag (1 = manual mode)
+ * @returns {Uint8Array}
+ */
+export function messageV3CameraParamSetExpGain(paramId, value, flag = 1) {
+  let module_id = Dwarfii_Api.ModuleId.MODULE_CAMERA_PARAMS;
+  let interface_id = Dwarfii_Api.DwarfCMD.CMD_V3_CAMERA_PARAMS_SET_EXP_GAIN;
+  let type_id = Dwarfii_Api.MessageTypeId.TYPE_REQUEST;
+  const cmdClass = cmdMapping[interface_id];
+  let class_message = Dwarfii_Api[cmdClass];
+  let message = class_message.create({
+    paramId: paramId,
+    flag: flag,
+    value: value,
+  });
+  console.log(
+    `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
+  );
+  return createPacket(message, class_message, module_id, interface_id, type_id);
+}
+/**
+ * V3: Adjust camera parameter (relative adjustment)
+ * Create Encoded Packet for the command CMD_V3_CAMERA_PARAMS_ADJUST (16703)
+ * @param {number} paramId - Parameter ID (encoded via encodeParamId)
+ * @param {number} value - Adjustment value (positive = increase, negative = decrease)
  * @returns {Uint8Array}
  */
 export function messageV3CameraParamsAdjust(paramId, value) {
@@ -26,4 +74,43 @@ export function messageV3CameraParamsAdjust(paramId, value) {
     `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
   );
   return createPacket(message, class_message, module_id, interface_id, type_id);
+}
+
+/**
+ * Encode a paramId from its constituent parts.
+ *
+ * paramId layout (64-bit integer):
+ *   bits [31..24] = shootingMode  (e.g. 0=photo, 1=video, 2=astro)
+ *   bits [23..16] = category      (parameter group)
+ *   bits [15..8]  = cameraId      (0=tele, 1=wide)
+ *   bits [7..0]   = paramIndex    (parameter index within the category)
+ *
+ * @param {number} shootingMode - Shooting mode (0=photo, 1=video, 2=astro)
+ * @param {number} category - Parameter category
+ * @param {number} cameraId - Camera ID (0=tele, 1=wide)
+ * @param {number} paramIndex - Parameter index within the category
+ * @returns {number} Encoded paramId
+ */
+export function encodeParamId(shootingMode, category, cameraId, paramIndex) {
+  return (
+    ((shootingMode & 0xff) << 24) |
+    ((category & 0xff) << 16) |
+    ((cameraId & 0xff) << 8) |
+    (paramIndex & 0xff)
+  );
+}
+
+/**
+ * Decode a paramId into its constituent parts.
+ *
+ * @param {number} paramId - Encoded parameter ID
+ * @returns {{ shootingMode: number, category: number, cameraId: number, paramIndex: number }}
+ */
+export function decodeParamId(paramId) {
+  return {
+    shootingMode: (paramId >> 24) & 0xff,
+    category: (paramId >> 16) & 0xff,
+    cameraId: (paramId >> 8) & 0xff,
+    paramIndex: paramId & 0xff,
+  };
 }

--- a/src/v3_camera_params.js
+++ b/src/v3_camera_params.js
@@ -79,7 +79,7 @@ export function messageV3CameraParamsAdjust(paramId, value) {
 /**
  * Encode a paramId from its constituent parts.
  *
- * paramId layout (64-bit integer):
+ * paramId layout (unsigned 32-bit packed into int64 proto field):
  *   bits [31..24] = shootingMode  (e.g. 0=photo, 1=video, 2=astro)
  *   bits [23..16] = category      (parameter group)
  *   bits [15..8]  = cameraId      (0=tele, 1=wide)
@@ -93,10 +93,11 @@ export function messageV3CameraParamsAdjust(paramId, value) {
  */
 export function encodeParamId(shootingMode, category, cameraId, paramIndex) {
   return (
-    ((shootingMode & 0xff) << 24) |
-    ((category & 0xff) << 16) |
-    ((cameraId & 0xff) << 8) |
-    (paramIndex & 0xff)
+    (((shootingMode & 0xff) << 24) |
+      ((category & 0xff) << 16) |
+      ((cameraId & 0xff) << 8) |
+      (paramIndex & 0xff)) >>>
+    0
   );
 }
 
@@ -107,10 +108,11 @@ export function encodeParamId(shootingMode, category, cameraId, paramIndex) {
  * @returns {{ shootingMode: number, category: number, cameraId: number, paramIndex: number }}
  */
 export function decodeParamId(paramId) {
+  const id = paramId >>> 0; // normalize to unsigned 32-bit
   return {
-    shootingMode: (paramId >> 24) & 0xff,
-    category: (paramId >> 16) & 0xff,
-    cameraId: (paramId >> 8) & 0xff,
-    paramIndex: paramId & 0xff,
+    shootingMode: (id >>> 24) & 0xff,
+    category: (id >>> 16) & 0xff,
+    cameraId: (id >>> 8) & 0xff,
+    paramIndex: id & 0xff,
   };
 }


### PR DESCRIPTION
## Summary

pcap解析で判明した V3 プロトコル定義の誤りを修正。

- **Issue #26 (AstroParams)**: `repeated` 未設定、フィールド番号誤り、レスポンスメッセージ欠落を修正
- **Issue #27 (CameraParams)**: `V3ReqSetCameraParam` のフィールド欠落を修正、通知フィールド名改善、encode/decode ヘルパー追加

## Changes

### Proto files
- `v3_astro.proto`: `V3ResGetAstroParams.params` を `repeated` に、`pipe_params` フィールド追加、`V3ResSetAstroParams` メッセージ新規追加
- `camera_params.proto`: `V3ReqSetCameraParam` に `flag` フィールド追加（16701 と同構造に）
- `v3_notify.proto`: `V3ResNotifyCameraParamState` のフィールド名を `flag`/`value` に、`V3ResNotifyStackingData` を WB 通知として明確化

### Source files
- `cmd_mapping.js`: CMD 11041 のレスポンスを `V3ResSetAstroParams` にマッピング
- `v3_camera_params.js`: `messageV3CameraParamSet()`, `messageV3CameraParamSetExpGain()`, `encodeParamId()`/`decodeParamId()` 追加
- `v3_astro.js`: JSDoc にパイプ形式の説明追加

## Test plan
- [x] `npm run compile-proto` passes
- [x] `npm run typecheck` passes
- [x] New functions exported and verified with encode/decode roundtrip
- [ ] Integration test with live DWARF mini device

Closes #26, Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)