### PR TITLE
fix: use port 80 for file downloads, port 8082 for API

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,7 +1,7 @@
 # HTTP API リファレンス
 
-DWARF mini / II / 3 が提供する HTTP API (ポート 8082) のリファレンスです。
-pcap 解析により発見されたエンドポイントを網羅しています。
+DWARF mini / II / 3 が提供する HTTP API のリファレンスです。
+pcap 解析および実機テストにより発見されたエンドポイントを網羅しています。
 
 ## 目次
 
@@ -17,7 +17,15 @@ pcap 解析により発見されたエンドポイントを網羅しています
 
 ## 概要
 
-- ベース URL: `http://<DEVICE_IP>:8082`
+デバイスは 2 つの HTTP サーバーを稼働しています:
+
+| ポート | 用途 | 例 |
+|--------|------|-----|
+| **8082** | JSON API (deviceInfo, album管理, 撮影モード, MJPEGストリーム) | `POST http://<IP>:8082/deviceInfo` |
+| **80** | 静的ファイル配信 (FITS, JPG, PNG, TIFF, サムネイル) | `GET http://<IP>:80/DWARF_mini/.../*.fits` |
+
+- API ベース URL: `http://<DEVICE_IP>:8082`
+- ファイルダウンロード URL: `http://<DEVICE_IP>:80`
 - POST リクエストは `Content-Type: application/json`
 - レスポンスは JSON 形式、成功時 `code: 0`
 
@@ -367,8 +375,10 @@ await albumDelete("192.168.88.1", [
 
 ## ファイルダウンロード
 
-デバイス上のファイルは静的アセットとして配信されます。
+デバイス上のファイルは**ポート 80** の静的ファイルサーバーから配信されます。
 ファイルパスを直接 GET するだけでダウンロードできます。
+
+> **注意:** JSON API (ポート 8082) ではファイルダウンロードできません (404 になります)。
 
 ### URL の組み立て
 
@@ -377,19 +387,19 @@ import { fileDownloadUrl, downloadFile } from "dwarfii_api";
 
 // URL を取得 (ブラウザで開く場合など)
 const url = fileDownloadUrl("192.168.88.1", "/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits");
-// => "http://192.168.88.1:8082/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits"
+// => "http://192.168.88.1:80/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits"
 ```
 
 ### curl でダウンロード
 
 ```bash
-# FITS ファイルをダウンロード
+# FITS ファイルをダウンロード (ポート 80)
 curl -o frame_001.fits \
-  http://192.168.88.1:8082/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits
+  http://192.168.88.1:80/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits
 
-# サムネイルをダウンロード
+# サムネイルをダウンロード (ポート 80)
 curl -o thumb.jpg \
-  http://192.168.88.1:8082/DWARF_mini/Astronomy/2026-03-01_M31/thumb.jpg
+  http://192.168.88.1:80/DWARF_mini/Astronomy/2026-03-01_M31/thumb.jpg
 ```
 
 ### JavaScript でダウンロード

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -29,12 +29,16 @@ pcap 解析および実機テストにより発見されたエンドポイント
 - POST リクエストは `Content-Type: application/json`
 - レスポンスは JSON 形式、成功時 `code: 0`
 
+> **インポートについて:** HTTP API ヘルパーはメインエントリポイント (`dwarfii_api`) からはエクスポートされていません。
+> メインエントリは WebSocket/Protobuf プロトコル関数のみをエクスポートしています。
+> HTTP API ヘルパーは `dwarfii_api/src/http_api.js` から直接インポートしてください。
+
 ```javascript
 import {
   getDeviceInfo,
   albumListMediaInfos,
   fileDownloadUrl,
-} from "dwarfii_api";
+} from "dwarfii_api/src/http_api.js";
 
 const IP = "192.168.88.1";
 
@@ -383,7 +387,7 @@ await albumDelete("192.168.88.1", [
 ### URL の組み立て
 
 ```javascript
-import { fileDownloadUrl, downloadFile } from "dwarfii_api";
+import { fileDownloadUrl, downloadFile } from "dwarfii_api/src/http_api.js";
 
 // URL を取得 (ブラウザで開く場合など)
 const url = fileDownloadUrl("192.168.88.1", "/DWARF_mini/Astronomy/2026-03-01_M31/frame_001.fits");
@@ -424,7 +428,7 @@ import {
   albumListMediaInfos,
   albumAstroFitsList,
   downloadFile,
-} from "dwarfii_api";
+} from "dwarfii_api/src/http_api.js";
 import { writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 
@@ -463,7 +467,7 @@ MJPEG ストリームは HTTP で直接取得できます。
 ### メインストリーム (望遠カメラ)
 
 ```javascript
-import { mainstreamUrl } from "dwarfii_api";
+import { mainstreamUrl } from "dwarfii_api/src/http_api.js";
 
 const url = mainstreamUrl("192.168.88.1");
 // => "http://192.168.88.1:8082/mainstream"
@@ -483,7 +487,7 @@ ffmpeg -i http://192.168.88.1:8082/mainstream -c copy output.mjpeg
 ### セカンドストリーム (広角カメラ)
 
 ```javascript
-import { secondstreamUrl } from "dwarfii_api";
+import { secondstreamUrl } from "dwarfii_api/src/http_api.js";
 
 const url = secondstreamUrl("192.168.88.1");
 // => "http://192.168.88.1:8082/secondstream"

--- a/src/http_api.d.ts
+++ b/src/http_api.d.ts
@@ -162,7 +162,7 @@ export type FitsListResponse = ApiResponse<{ fitsInfo: FitsFileInfo[] }>;
 export declare function mainstreamUrl(IP: string): string;
 export declare function secondstreamUrl(IP: string): string;
 
-// File download
+// File download (port 80 — static file server)
 export declare function fileDownloadUrl(IP: string, filePath: string): string;
 export declare function downloadFile(
   IP: string,

--- a/src/http_api.js
+++ b/src/http_api.js
@@ -1,23 +1,37 @@
 /** @module http_api */
 // HTTP API wrapper for DWARF mini / II / 3 file download and album management.
-// All endpoints are served on port 8082 of the device.
+//
+// The device runs two HTTP servers:
+//   - Port 8082: JSON API (deviceInfo, album management, shooting modes, MJPEG streams)
+//   - Port 80:   Static file server (FITS, JPG, PNG, TIFF, thumbnails)
 //
 // Runtime requirement: global `fetch` (Node.js 18+ or browser).
 // For older Node.js runtimes, polyfill with `undici` or `node-fetch`.
 
-const DEFAULT_HTTP_PORT = 8082;
+const DEFAULT_API_PORT = 8082;
+const DEFAULT_FILE_PORT = 80;
 
 /*** --------------------------------------------------------- ***/
 /*** ------------- URL BUILDERS ------------------------------ ***/
 /*** --------------------------------------------------------- ***/
 
 /**
- * Build the base URL for the HTTP API.
+ * Build the base URL for the JSON API (port 8082).
  * @param {string} IP - Device IP address
- * @param {number} [port=8082] - HTTP port
+ * @param {number} [port=8082] - API port
  * @returns {string}
  */
-function baseUrl(IP, port = DEFAULT_HTTP_PORT) {
+function apiBaseUrl(IP, port = DEFAULT_API_PORT) {
+  return `http://${IP}:${port}`;
+}
+
+/**
+ * Build the base URL for static file downloads (port 80).
+ * @param {string} IP - Device IP address
+ * @param {number} [port=80] - File server port
+ * @returns {string}
+ */
+function fileBaseUrl(IP, port = DEFAULT_FILE_PORT) {
   return `http://${IP}:${port}`;
 }
 
@@ -31,7 +45,7 @@ function baseUrl(IP, port = DEFAULT_HTTP_PORT) {
  * @returns {string}
  */
 export function mainstreamUrl(IP) {
-  return `${baseUrl(IP)}/mainstream`;
+  return `${apiBaseUrl(IP)}/mainstream`;
 }
 
 /**
@@ -40,7 +54,7 @@ export function mainstreamUrl(IP) {
  * @returns {string}
  */
 export function secondstreamUrl(IP) {
-  return `${baseUrl(IP)}/secondstream`;
+  return `${apiBaseUrl(IP)}/secondstream`;
 }
 
 /*** --------------------------------------------------------- ***/
@@ -49,13 +63,13 @@ export function secondstreamUrl(IP) {
 
 /**
  * Build the full download URL for a file on the device.
- * Files are served as static assets — just GET the returned URL.
+ * Files are served on port 80 as static assets — just GET the returned URL.
  * @param {string} IP - Device IP address
  * @param {string} filePath - Absolute file path on device (e.g. "/DWARF_mini/Astronomy/.../xxx.fits")
  * @returns {string}
  */
 export function fileDownloadUrl(IP, filePath) {
-  return `${baseUrl(IP)}${filePath}`;
+  return `${fileBaseUrl(IP)}${filePath}`;
 }
 
 /**
@@ -87,7 +101,7 @@ export async function downloadFile(IP, filePath) {
  * @returns {Promise<Object>}
  */
 export async function getDeviceInfo(IP) {
-  const url = `${baseUrl(IP)}/deviceInfo`;
+  const url = `${apiBaseUrl(IP)}/deviceInfo`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -108,7 +122,7 @@ export async function getDeviceInfo(IP) {
  * @returns {Promise<Object>}
  */
 export async function getDeviceActivateInfo(IP) {
-  const url = `${baseUrl(IP)}/getDeviceActivateInfo`;
+  const url = `${apiBaseUrl(IP)}/getDeviceActivateInfo`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -131,7 +145,7 @@ export async function getDeviceActivateInfo(IP) {
  * @returns {Promise<Object>}
  */
 export async function fetchDefaultParamsConfig(IP) {
-  const url = `${baseUrl(IP)}/getDefaultParamsConfig`;
+  const url = `${apiBaseUrl(IP)}/getDefaultParamsConfig`;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(
@@ -148,7 +162,7 @@ export async function fetchDefaultParamsConfig(IP) {
  * @returns {Promise<Object>}
  */
 export async function getFirmwareVersion(IP) {
-  const url = `${baseUrl(IP)}/firmwareVersion`;
+  const url = `${apiBaseUrl(IP)}/firmwareVersion`;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(
@@ -169,7 +183,7 @@ export async function getFirmwareVersion(IP) {
  * @returns {Promise<Object>}
  */
 export async function getSupportedShootingModes(IP) {
-  const url = `${baseUrl(IP)}/shootingMode/getSupportedShootingModes`;
+  const url = `${apiBaseUrl(IP)}/shootingMode/getSupportedShootingModes`;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(
@@ -186,7 +200,7 @@ export async function getSupportedShootingModes(IP) {
  * @returns {Promise<Object>}
  */
 export async function getParamAndSetting(IP) {
-  const url = `${baseUrl(IP)}/shootingMode/getParamAndSetting`;
+  const url = `${apiBaseUrl(IP)}/shootingMode/getParamAndSetting`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -212,7 +226,7 @@ export async function getParamAndSetting(IP) {
  * @returns {Promise<Object>}
  */
 export async function albumListMediaCounts(IP) {
-  const url = `${baseUrl(IP)}/album/list/mediaCounts`;
+  const url = `${apiBaseUrl(IP)}/album/list/mediaCounts`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -238,7 +252,7 @@ export async function albumListMediaInfos(
   IP,
   mediaTypeList = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 ) {
-  const url = `${baseUrl(IP)}/album/list/mediaInfos`;
+  const url = `${apiBaseUrl(IP)}/album/list/mediaInfos`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -261,7 +275,7 @@ export async function albumListMediaInfos(
  * @returns {Promise<Object>}
  */
 export async function albumAstroFitsList(IP, srcDir) {
-  const url = `${baseUrl(IP)}/album/astro/fitsList`;
+  const url = `${apiBaseUrl(IP)}/album/astro/fitsList`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -283,7 +297,7 @@ export async function albumAstroFitsList(IP, srcDir) {
  * @returns {Promise<Object>}
  */
 export async function albumDelete(IP, datas) {
-  const url = `${baseUrl(IP)}/album/delete`;
+  const url = `${apiBaseUrl(IP)}/album/delete`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/src/http_api.js
+++ b/src/http_api.js
@@ -1,6 +1,11 @@
 /** @module http_api */
 // HTTP API wrapper for DWARF mini / II / 3 file download and album management.
 //
+// This module is NOT exported from the package main entry point (dist/index.js),
+// which exclusively exports WebSocket/protobuf protocol functions.
+// Import directly:
+//   import { fileDownloadUrl, downloadFile } from "dwarfii_api/src/http_api.js";
+//
 // The device runs two HTTP servers:
 //   - Port 8082: JSON API (deviceInfo, album management, shooting modes, MJPEG streams)
 //   - Port 80:   Static file server (FITS, JPG, PNG, TIFF, thumbnails)


### PR DESCRIPTION
## Summary

- Real device testing (DWARF mini FW 1.0.25.2) revealed that static files are served on **port 80**, not port 8082
- Port 8082 is exclusively for JSON API endpoints
- Split `baseUrl` into `apiBaseUrl` (port 8082) and `fileBaseUrl` (port 80)
- Updated `fileDownloadUrl()` and `downloadFile()` to use port 80
- Updated docs with correct port information and architecture table

## Test plan

- [ ] Verify `fileDownloadUrl("192.168.11.31", "/DWARF_mini/...")` returns URL with port 80
- [ ] Verify `downloadFile()` successfully downloads FITS/JPG from real device
- [ ] Verify API endpoints (`getDeviceInfo`, `albumListMediaCounts`, etc.) still use port 8082

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)