### PR TITLE
fix: correct stream URLs from MJPEG port 8082 to RTSP port 554

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1,6 +1,6 @@
 # HTTP API リファレンス
 
-DWARF mini / II / 3 が提供する HTTP API のリファレンスです。
+DWARF mini / II / 3 が提供する HTTP / RTSP API のリファレンスです。
 pcap 解析および実機テストにより発見されたエンドポイントを網羅しています。
 
 ## 目次
@@ -11,21 +11,25 @@ pcap 解析および実機テストにより発見されたエンドポイント
 - [撮影モード](#撮影モード)
 - [アルバム管理](#アルバム管理)
 - [ファイルダウンロード](#ファイルダウンロード)
-- [ストリーミング](#ストリーミング)
+- [カメラストリーミング](#カメラストリーミング)
 
 ---
 
 ## 概要
 
-デバイスは 2 つの HTTP サーバーを稼働しています:
+デバイスは複数のサーバーを稼働しています:
 
 | ポート | 用途 | 例 |
 |--------|------|-----|
-| **8082** | JSON API (deviceInfo, album管理, 撮影モード, MJPEGストリーム) | `POST http://<IP>:8082/deviceInfo` |
+| **8082** | JSON API (deviceInfo, album管理, 撮影モード) | `POST http://<IP>:8082/deviceInfo` |
 | **80** | 静的ファイル配信 (FITS, JPG, PNG, TIFF, サムネイル) | `GET http://<IP>:80/DWARF_mini/.../*.fits` |
+| **554** | RTSP ストリーミング (実際に動作するカメラストリーム) | `rtsp://<IP>:554/ch0/stream0` |
+| **8092** | MJPEG エンドポイント (存在するが 0 バイトを返す) | `http://<IP>:8092/mainstream` |
 
-- API ベース URL: `http://<DEVICE_IP>:8082`
+- JSON API ベース URL: `http://<DEVICE_IP>:8082`
 - ファイルダウンロード URL: `http://<DEVICE_IP>:80`
+- RTSP ストリーミング: `rtsp://<DEVICE_IP>:554` (実際に動作するカメラストリーム)
+- MJPEG エンドポイント: `http://<DEVICE_IP>:8092` (存在するが 0 バイトを返す)
 - POST リクエストは `Content-Type: application/json`
 - レスポンスは JSON 形式、成功時 `code: 0`
 
@@ -460,43 +464,55 @@ for (const media of mediaInfos.data) {
 
 ---
 
-## ストリーミング
+## カメラストリーミング
 
-MJPEG ストリームは HTTP で直接取得できます。
+### RTSP ストリーミング (ポート 554) -- 推奨
 
-### メインストリーム (望遠カメラ)
+実機テストにより、DWARF mini / 3 のカメラストリームは **RTSP (ポート 554)** で提供されることが確認されています。
+DWARF mini と DWARF 3 は同じ RTSP アプローチを使用しています。
+
+| カメラ | RTSP URL | チャンネル |
+|--------|----------|-----------|
+| 望遠 (Tele) | `rtsp://<IP>:554/ch0/stream0` | ch0 |
+| 広角 (Wide) | `rtsp://<IP>:554/ch1/stream0` | ch1 |
 
 ```javascript
-import { mainstreamUrl } from "dwarfii_api/src/http_api.js";
+import { rtspTeleUrl, rtspWideUrl } from "dwarfii_api/src/http_api.js";
 
-const url = mainstreamUrl("192.168.88.1");
-// => "http://192.168.88.1:8082/mainstream"
+const teleUrl = rtspTeleUrl("192.168.88.1");
+// => "rtsp://192.168.88.1:554/ch0/stream0"
 
-// HTML の <img> タグで表示可能
-// <img src="http://192.168.88.1:8082/mainstream" />
+const wideUrl = rtspWideUrl("192.168.88.1");
+// => "rtsp://192.168.88.1:554/ch1/stream0"
 ```
 
 ```bash
-# VLC で表示
-vlc http://192.168.88.1:8082/mainstream
+# VLC で望遠カメラストリームを表示
+vlc rtsp://192.168.88.1:554/ch0/stream0
 
-# ffmpeg で録画
-ffmpeg -i http://192.168.88.1:8082/mainstream -c copy output.mjpeg
+# ffmpeg で広角カメラストリームを録画
+ffmpeg -rtsp_transport tcp -i rtsp://192.168.88.1:554/ch1/stream0 -c copy output.mp4
+
+# ffplay でリアルタイム表示
+ffplay -rtsp_transport tcp rtsp://192.168.88.1:554/ch0/stream0
 ```
 
-### セカンドストリーム (広角カメラ)
+### MJPEG エンドポイント (ポート 8092) -- 非推奨
+
+MJPEG エンドポイントはポート 8092 に存在しますが、実機テストでは **0 バイト** を返すことが確認されています。
+実用的なストリーミングには上記の RTSP を使用してください。
+
+> **注意:** 以前のドキュメントではポート 8082 に MJPEG ストリームがあると記載されていましたが、
+> これは誤りでした。MJPEG エンドポイントはポート 8092 に存在し (ただしデータなし)、
+> ポート 8082 は JSON API 専用です。
 
 ```javascript
-import { secondstreamUrl } from "dwarfii_api/src/http_api.js";
+import { mainstreamUrl, secondstreamUrl } from "dwarfii_api/src/http_api.js";
 
-const url = secondstreamUrl("192.168.88.1");
-// => "http://192.168.88.1:8082/secondstream"
+// これらの URL は存在するが、実際にはデータを返さない
+const mjpegTele = mainstreamUrl("192.168.88.1");
+// => "http://192.168.88.1:8092/mainstream"
+
+const mjpegWide = secondstreamUrl("192.168.88.1");
+// => "http://192.168.88.1:8092/secondstream"
 ```
-
-```bash
-vlc http://192.168.88.1:8082/secondstream
-```
-
-> **注意:** DWARF II / 3 では従来ポート 8092 でストリーミングが提供されていましたが、
-> DWARF mini ではポート 8082 に統一されています。
-> 既存の `api_codes.js` の `telephotoURL` / `wideangleURL` (ポート 8092) と混同しないよう注意してください。

--- a/src/http_api.d.ts
+++ b/src/http_api.d.ts
@@ -156,10 +156,41 @@ export type MediaInfosResponse = ApiResponse<MediaInfo[]>;
 /** Response from /album/astro/fitsList */
 export type FitsListResponse = ApiResponse<{ fitsInfo: FitsFileInfo[] }>;
 
+// ---- Constants ----
+
+export declare const DEFAULT_RTSP_PORT: 554;
+export declare const DEFAULT_MJPEG_PORT: 8092;
+
 // ---- Function signatures ----
 
-// Streaming URLs
+// RTSP streaming (actual working protocol)
+
+/**
+ * Get the RTSP URL for the telephoto (main) camera stream.
+ * This is the actual working stream protocol used by DWARF mini / 3.
+ */
+export declare function rtspTeleUrl(IP: string, port?: number): string;
+
+/**
+ * Get the RTSP URL for the wide-angle camera stream.
+ * This is the actual working stream protocol used by DWARF mini / 3.
+ */
+export declare function rtspWideUrl(IP: string, port?: number): string;
+
+// MJPEG streaming (endpoint exists but returns 0 bytes)
+
+/**
+ * Get the mainstream (telephoto) MJPEG stream URL (port 8092).
+ * NOTE: This endpoint exists on the device but returns 0 bytes in practice.
+ * Use rtspTeleUrl() for actual camera streaming.
+ */
 export declare function mainstreamUrl(IP: string): string;
+
+/**
+ * Get the second stream (wide-angle) MJPEG stream URL (port 8092).
+ * NOTE: This endpoint exists on the device but returns 0 bytes in practice.
+ * Use rtspWideUrl() for actual camera streaming.
+ */
 export declare function secondstreamUrl(IP: string): string;
 
 // File download (port 80 — static file server)

--- a/src/http_api.js
+++ b/src/http_api.js
@@ -6,15 +6,19 @@
 // Import directly:
 //   import { fileDownloadUrl, downloadFile } from "dwarfii_api/src/http_api.js";
 //
-// The device runs two HTTP servers:
-//   - Port 8082: JSON API (deviceInfo, album management, shooting modes, MJPEG streams)
+// The device runs multiple servers:
+//   - Port 8082: JSON API (deviceInfo, album management, shooting modes)
 //   - Port 80:   Static file server (FITS, JPG, PNG, TIFF, thumbnails)
+//   - Port 554:  RTSP streaming (actual working camera streams)
+//   - Port 8092: MJPEG streaming (endpoint exists but returns 0 bytes)
 //
 // Runtime requirement: global `fetch` (Node.js 18+ or browser).
 // For older Node.js runtimes, polyfill with `undici` or `node-fetch`.
 
 const DEFAULT_API_PORT = 8082;
 const DEFAULT_FILE_PORT = 80;
+export const DEFAULT_RTSP_PORT = 554;
+export const DEFAULT_MJPEG_PORT = 8092;
 
 /*** --------------------------------------------------------- ***/
 /*** ------------- URL BUILDERS ------------------------------ ***/
@@ -45,21 +49,47 @@ function fileBaseUrl(IP, port = DEFAULT_FILE_PORT) {
 /*** --------------------------------------------------------- ***/
 
 /**
- * Get the mainstream (telephoto) MJPEG stream URL.
+ * Get the RTSP URL for the telephoto (main) camera stream.
+ * This is the actual working stream protocol used by DWARF mini / 3.
+ * @param {string} IP - Device IP address
+ * @param {number} [port=554] - RTSP port
+ * @returns {string} e.g. "rtsp://192.168.88.1:554/ch0/stream0"
+ */
+export function rtspTeleUrl(IP, port = DEFAULT_RTSP_PORT) {
+  return `rtsp://${IP}:${port}/ch0/stream0`;
+}
+
+/**
+ * Get the RTSP URL for the wide-angle camera stream.
+ * This is the actual working stream protocol used by DWARF mini / 3.
+ * @param {string} IP - Device IP address
+ * @param {number} [port=554] - RTSP port
+ * @returns {string} e.g. "rtsp://192.168.88.1:554/ch1/stream0"
+ */
+export function rtspWideUrl(IP, port = DEFAULT_RTSP_PORT) {
+  return `rtsp://${IP}:${port}/ch1/stream0`;
+}
+
+/**
+ * Get the mainstream (telephoto) MJPEG stream URL (port 8092).
+ * NOTE: This endpoint exists on the device but returns 0 bytes in practice.
+ * Use {@link rtspTeleUrl} for actual camera streaming.
  * @param {string} IP - Device IP address
  * @returns {string}
  */
 export function mainstreamUrl(IP) {
-  return `${apiBaseUrl(IP)}/mainstream`;
+  return `http://${IP}:${DEFAULT_MJPEG_PORT}/mainstream`;
 }
 
 /**
- * Get the second stream (wide-angle) MJPEG stream URL.
+ * Get the second stream (wide-angle) MJPEG stream URL (port 8092).
+ * NOTE: This endpoint exists on the device but returns 0 bytes in practice.
+ * Use {@link rtspWideUrl} for actual camera streaming.
  * @param {string} IP - Device IP address
  * @returns {string}
  */
 export function secondstreamUrl(IP) {
-  return `${apiBaseUrl(IP)}/secondstream`;
+  return `http://${IP}:${DEFAULT_MJPEG_PORT}/secondstream`;
 }
 
 /*** --------------------------------------------------------- ***/


### PR DESCRIPTION
## 概要

実機テストにより、DWARF mini のカメラストリームは RTSP (ポート 554) で提供されることが確認されました。従来の MJPEG (ポート 8082) は誤りでした。

## 変更内容

- `rtspTeleUrl()` / `rtspWideUrl()` を新規追加 (RTSP ポート 554、実際に動作するプロトコル)
- `mainstreamUrl()` / `secondstreamUrl()` のポートを 8082 → 8092 に修正 (MJPEG エンドポイントの正しいポート)
- MJPEG は存在するがデータを返さない旨を JSDoc に明記
- `DEFAULT_RTSP_PORT` (554) / `DEFAULT_MJPEG_PORT` (8092) 定数をエクスポート
- 型定義ファイル (`http_api.d.ts`) に新規関数の宣言を追加
- ドキュメント (`HTTP_API.md`) のストリーミングセクションを RTSP 中心に書き直し

## 実機テスト結果

| プロトコル | ポート | URL パターン | 状態 |
|-----------|--------|-------------|------|
| RTSP | 554 | `rtsp://{IP}:554/ch0/stream0` (望遠) | 動作確認済 |
| RTSP | 554 | `rtsp://{IP}:554/ch1/stream0` (広角) | 動作確認済 |
| MJPEG | 8092 | `http://{IP}:8092/mainstream` | エンドポイント存在、0 バイト |
| HTTP API | 8082 | JSON API のみ | ストリーム非対応 |

## テスト計画

- [ ] `rtspTeleUrl("192.168.88.1")` が `"rtsp://192.168.88.1:554/ch0/stream0"` を返すことを確認
- [ ] `rtspWideUrl("192.168.88.1")` が `"rtsp://192.168.88.1:554/ch1/stream0"` を返すことを確認
- [ ] `mainstreamUrl("192.168.88.1")` が `"http://192.168.88.1:8092/mainstream"` を返すことを確認
- [ ] `secondstreamUrl("192.168.88.1")` が `"http://192.168.88.1:8092/secondstream"` を返すことを確認
- [ ] カスタムポート指定: `rtspTeleUrl("192.168.88.1", 8554)` が正しく動作することを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)