### PR TITLE
feat: add motor joystick and manual focus wrapper functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ export * from "./src/system.js";
 export * from "./src/websocket_class.js";
 export * from "./src/bluetooth.js";
 export * from "./src/motor.js";
+export * from "./src/v3_motor.js";
 export * from "./src/v3_camera_tele.js";
 export * from "./src/v3_camera_wide.js";
 export * from "./src/v3_astro.js";

--- a/src/v3_focus.js
+++ b/src/v3_focus.js
@@ -43,3 +43,56 @@ export function messageV3FocusAutoFocusStart() {
   );
   return createPacket(message, class_message, module_id, interface_id, type_id);
 }
+/**
+ * V3: Manual single-step focus
+ * Create Encoded Packet for the command CMD_FOCUS_MANUAL_SINGLE_STEP_FOCUS
+ * @param {number} direction - Focus direction (0=forward, 1=backward)
+ * @returns {Uint8Array}
+ */
+export function messageV3FocusManualSingleStep(direction = 0) {
+  let module_id = Dwarfii_Api.ModuleId.MODULE_FOCUS;
+  let interface_id = Dwarfii_Api.DwarfCMD.CMD_FOCUS_MANUAL_SINGLE_STEP_FOCUS;
+  let type_id = Dwarfii_Api.MessageTypeId.TYPE_REQUEST;
+  const cmdClass = cmdMapping[interface_id];
+  let class_message = Dwarfii_Api[cmdClass];
+  let message = class_message.create({ direction: direction });
+  console.log(
+    `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
+  );
+  return createPacket(message, class_message, module_id, interface_id, type_id);
+}
+/**
+ * V3: Start manual continuous focus
+ * Create Encoded Packet for the command CMD_FOCUS_START_MANUAL_CONTINU_FOCUS
+ * @param {number} direction - Focus direction (0=forward, 1=backward)
+ * @returns {Uint8Array}
+ */
+export function messageV3FocusManualContinuStart(direction = 0) {
+  let module_id = Dwarfii_Api.ModuleId.MODULE_FOCUS;
+  let interface_id = Dwarfii_Api.DwarfCMD.CMD_FOCUS_START_MANUAL_CONTINU_FOCUS;
+  let type_id = Dwarfii_Api.MessageTypeId.TYPE_REQUEST;
+  const cmdClass = cmdMapping[interface_id];
+  let class_message = Dwarfii_Api[cmdClass];
+  let message = class_message.create({ direction: direction });
+  console.log(
+    `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
+  );
+  return createPacket(message, class_message, module_id, interface_id, type_id);
+}
+/**
+ * V3: Stop manual continuous focus
+ * Create Encoded Packet for the command CMD_FOCUS_STOP_MANUAL_CONTINU_FOCUS
+ * @returns {Uint8Array}
+ */
+export function messageV3FocusManualContinuStop() {
+  let module_id = Dwarfii_Api.ModuleId.MODULE_FOCUS;
+  let interface_id = Dwarfii_Api.DwarfCMD.CMD_FOCUS_STOP_MANUAL_CONTINU_FOCUS;
+  let type_id = Dwarfii_Api.MessageTypeId.TYPE_REQUEST;
+  const cmdClass = cmdMapping[interface_id];
+  let class_message = Dwarfii_Api[cmdClass];
+  let message = class_message.create({});
+  console.log(
+    `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
+  );
+  return createPacket(message, class_message, module_id, interface_id, type_id);
+}

--- a/src/v3_motor.js
+++ b/src/v3_motor.js
@@ -1,0 +1,49 @@
+/** @module v3_motor */
+// Import the generated protobuf module
+import $root from "./protobuf/protobuf.js";
+const Dwarfii_Api = $root;
+import { createPacket } from "./api_utils.js";
+import { cmdMapping } from "./cmd_mapping.js";
+
+/*** --------------------------------------------------------- ***/
+/*** ------------- V3 MODULE MOTOR (14xxx) ------------------- ***/
+/*** --------------------------------------------------------- ***/
+/**
+ * V3: Joystick motor control
+ * Create Encoded Packet for the command CMD_STEP_MOTOR_SERVICE_JOYSTICK
+ * @param {number} vectorAngle - Direction 0-360 degrees (up=90, down=270, left=180, right=0/360)
+ * @param {number} vectorLength - Speed scaling factor 0.0-1.0
+ * @returns {Uint8Array}
+ */
+export function messageV3MotorServiceJoystick(vectorAngle, vectorLength) {
+  let module_id = Dwarfii_Api.ModuleId.MODULE_MOTOR;
+  let interface_id = Dwarfii_Api.DwarfCMD.CMD_STEP_MOTOR_SERVICE_JOYSTICK;
+  let type_id = Dwarfii_Api.MessageTypeId.TYPE_REQUEST;
+  const cmdClass = cmdMapping[interface_id];
+  let class_message = Dwarfii_Api[cmdClass];
+  let message = class_message.create({
+    vectorAngle: vectorAngle,
+    vectorLength: vectorLength,
+  });
+  console.log(
+    `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
+  );
+  return createPacket(message, class_message, module_id, interface_id, type_id);
+}
+/**
+ * V3: Stop joystick motor control
+ * Create Encoded Packet for the command CMD_STEP_MOTOR_SERVICE_JOYSTICK_STOP
+ * @returns {Uint8Array}
+ */
+export function messageV3MotorServiceJoystickStop() {
+  let module_id = Dwarfii_Api.ModuleId.MODULE_MOTOR;
+  let interface_id = Dwarfii_Api.DwarfCMD.CMD_STEP_MOTOR_SERVICE_JOYSTICK_STOP;
+  let type_id = Dwarfii_Api.MessageTypeId.TYPE_REQUEST;
+  const cmdClass = cmdMapping[interface_id];
+  let class_message = Dwarfii_Api[cmdClass];
+  let message = class_message.create({});
+  console.log(
+    `class Message = ${cmdClass} created message = ${JSON.stringify(message)}`
+  );
+  return createPacket(message, class_message, module_id, interface_id, type_id);
+}


### PR DESCRIPTION
## Summary

モーター制御（ジョイスティック）とマニュアルフォーカスのV3ラッパー関数を追加。

- `src/v3_motor.js` (新規): ジョイスティックによるモーター制御
  - `messageV3MotorServiceJoystick(vectorAngle, vectorLength)` — CMD 14006
  - `messageV3MotorServiceJoystickStop()` — CMD 14008
- `src/v3_focus.js` (追記): マニュアルフォーカス操作
  - `messageV3FocusManualSingleStep(direction)` — CMD 15001
  - `messageV3FocusManualContinuStart(direction)` — CMD 15002
  - `messageV3FocusManualContinuStop()` — CMD 15003
- `index.js`: `v3_motor` のエクスポートを追加

### 設計方針

- 既存の `v3_focus.js` / `v3_astro.js` と同じパターンに準拠
- `eval()` ではなく `Dwarfii_Api[cmdClass]` のブラケット記法を使用（V3スタイル）
- ジョイスティック関数は `vectorAngle` と `vectorLength` のみ送信（`speed` フィールドはpcapで未使用のため省略）

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)