### PR TITLE
test: add tele camera RTSP/MJPEG probe scripts

### DIFF
--- a/tools/v3-probe/tele-test.cjs
+++ b/tools/v3-probe/tele-test.cjs
@@ -1,0 +1,88 @@
+// Quick test: send V3 camera open with deviceId=4, then probe RTSP
+const WebSocket = require('ws');
+const protobuf = require('protobufjs');
+const { execSync } = require('child_process');
+
+const IP = '192.168.11.31';
+
+async function main() {
+  const root = await protobuf.load('src/proto/base.proto');
+  const WsPacket = root.lookupType('WsPacket');
+
+  const ws = new WebSocket(`ws://${IP}:9900`);
+  ws.binaryType = 'arraybuffer';
+
+  function sendPacket(moduleId, cmd, deviceId, innerHex) {
+    const packet = {
+      majorVersion: 1,
+      minorVersion: 20,
+      deviceId: deviceId,
+      moduleId: moduleId,
+      cmd: cmd,
+      data: innerHex ? Buffer.from(innerHex, 'hex') : undefined,
+    };
+    const encoded = WsPacket.encode(WsPacket.create(packet)).finish();
+    ws.send(encoded);
+    console.log(`>>> mod:${moduleId} cmd:${cmd} devId:${deviceId}${innerHex ? ' data:' + innerHex : ''}`);
+  }
+
+  ws.on('message', (data) => {
+    try {
+      const decoded = WsPacket.decode(Buffer.from(data));
+      console.log(`<<< mod:${decoded.moduleId} cmd:${decoded.cmd} type:${decoded.type}`);
+    } catch(e) {}
+  });
+
+  ws.on('open', async () => {
+    console.log('WS connected');
+
+    // ModeSwitch to preview (deviceId=4)
+    console.log('\n1. ModeSwitch (CMD 16404, devId=4)');
+    sendPacket(14, 16404, 4, '1a020801');
+    await sleep(1000);
+
+    // Open tele camera (CMD 10050, devId=4, action=1)
+    console.log('\n2. Open tele (CMD 10050, devId=4)');
+    sendPacket(1, 10050, 4, '0801');
+    await sleep(1000);
+
+    // Open wide camera (CMD 12036, devId=4, no args)
+    console.log('\n3. Open wide (CMD 12036, devId=4)');
+    sendPacket(2, 12036, 4);
+
+    // Wait for RTSP to start
+    console.log('\n4. Waiting 5s for RTSP...');
+    await sleep(5000);
+
+    // Probe RTSP
+    console.log('\n5. Probing RTSP tele (ch0/stream0)...');
+    try {
+      const out = execSync(
+        `ffprobe -rtsp_transport tcp -i rtsp://${IP}:554/ch0/stream0 -timeout 5000000 2>&1`,
+        { timeout: 10000 }
+      ).toString();
+      console.log(out);
+    } catch(e) {
+      console.log(e.stdout?.toString() || e.stderr?.toString() || e.message);
+    }
+
+    console.log('\n6. Probing RTSP wide (ch1/stream0)...');
+    try {
+      const out = execSync(
+        `ffprobe -rtsp_transport tcp -i rtsp://${IP}:554/ch1/stream0 -timeout 5000000 2>&1`,
+        { timeout: 10000 }
+      ).toString();
+      console.log(out);
+    } catch(e) {
+      console.log(e.stdout?.toString() || e.stderr?.toString() || e.message);
+    }
+
+    ws.close();
+    process.exit(0);
+  });
+
+  ws.on('error', (err) => console.error('WS Error:', err.message));
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+main().catch(console.error);

--- a/tools/v3-probe/tele-test2.cjs
+++ b/tools/v3-probe/tele-test2.cjs
@@ -1,0 +1,81 @@
+// Test: send V3 camera open with full data decode
+const WebSocket = require('ws');
+const protobuf = require('protobufjs');
+const { execSync } = require('child_process');
+
+const IP = '192.168.11.31';
+
+async function main() {
+  const root = await protobuf.load('src/proto/base.proto');
+  const WsPacket = root.lookupType('WsPacket');
+
+  const ws = new WebSocket(`ws://${IP}:9900`);
+  ws.binaryType = 'arraybuffer';
+
+  function sendPacket(moduleId, cmd, deviceId, innerHex) {
+    const packet = {
+      majorVersion: 1,
+      minorVersion: 20,
+      deviceId: deviceId,
+      moduleId: moduleId,
+      cmd: cmd,
+      data: innerHex ? Buffer.from(innerHex, 'hex') : undefined,
+    };
+    ws.send(WsPacket.encode(WsPacket.create(packet)).finish());
+    console.log(`>>> mod:${moduleId} cmd:${cmd} devId:${deviceId}${innerHex ? ' data:' + innerHex : ''}`);
+  }
+
+  ws.on('message', (data) => {
+    try {
+      const decoded = WsPacket.decode(Buffer.from(data));
+      const hex = decoded.data && decoded.data.length > 0
+        ? Buffer.from(decoded.data).toString('hex')
+        : '';
+      console.log(`<<< mod:${decoded.moduleId} cmd:${decoded.cmd} type:${decoded.type} data:${hex}`);
+    } catch(e) {
+      console.log(`<<< raw: ${Buffer.from(data).toString('hex').slice(0, 80)}`);
+    }
+  });
+
+  ws.on('open', async () => {
+    console.log('WS connected\n');
+
+    // Full init: ModeSwitch first
+    console.log('1. ModeSwitch (CMD 16404, devId=4)');
+    sendPacket(14, 16404, 4, '1a020801');
+    await sleep(1000);
+
+    // Open tele (CMD 10050) — action=1 = open
+    console.log('\n2. Open tele (CMD 10050, devId=4, action=1)');
+    sendPacket(1, 10050, 4, '0801');
+    await sleep(2000);
+
+    // Open wide (CMD 12036) — no args = open
+    console.log('\n3. Open wide (CMD 12036, devId=4)');
+    sendPacket(2, 12036, 4);
+    await sleep(2000);
+
+    // Check for stream notifications
+    console.log('\n4. Waiting 8s for stream init...');
+    await sleep(8000);
+
+    // Probe
+    console.log('\n5. RTSP probe tele:');
+    try {
+      execSync(`ffprobe -rtsp_transport tcp -i rtsp://${IP}:554/ch0/stream0 -timeout 3000000 2>&1`, { timeout: 8000, stdio: 'inherit' });
+    } catch(e) {}
+
+    console.log('\n6. RTSP probe wide:');
+    try {
+      execSync(`ffprobe -rtsp_transport tcp -i rtsp://${IP}:554/ch1/stream0 -timeout 3000000 2>&1`, { timeout: 8000, stdio: 'inherit' });
+    } catch(e) {}
+
+    ws.close();
+    process.exit(0);
+  });
+
+  ws.on('error', (err) => console.error('WS Error:', err.message));
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+main().catch(console.error);

--- a/tools/v3-probe/tele-test3.cjs
+++ b/tools/v3-probe/tele-test3.cjs
@@ -1,0 +1,116 @@
+// Test: keep WS alive, send V3 camera open, probe both RTSP and MJPEG
+const WebSocket = require('ws');
+const protobuf = require('protobufjs');
+const { exec } = require('child_process');
+const http = require('http');
+
+const IP = '192.168.11.31';
+
+async function main() {
+  const root = await protobuf.load('src/proto/base.proto');
+  const WsPacket = root.lookupType('WsPacket');
+
+  const ws = new WebSocket(`ws://${IP}:9900`);
+  ws.binaryType = 'arraybuffer';
+
+  function sendPacket(moduleId, cmd, deviceId, innerHex) {
+    const packet = {
+      majorVersion: 1,
+      minorVersion: 20,
+      deviceId: deviceId,
+      moduleId: moduleId,
+      cmd: cmd,
+      data: innerHex ? Buffer.from(innerHex, 'hex') : undefined,
+    };
+    ws.send(WsPacket.encode(WsPacket.create(packet)).finish());
+    console.log(`>>> mod:${moduleId} cmd:${cmd} devId:${deviceId}${innerHex ? ' data:' + innerHex : ''}`);
+  }
+
+  ws.on('message', (data) => {
+    try {
+      const decoded = WsPacket.decode(Buffer.from(data));
+      const hex = decoded.data?.length > 0 ? Buffer.from(decoded.data).toString('hex') : '';
+      console.log(`<<< mod:${decoded.moduleId} cmd:${decoded.cmd} type:${decoded.type} data:${hex}`);
+    } catch(e) {}
+  });
+
+  ws.on('open', async () => {
+    console.log('WS connected (keeping alive)\n');
+
+    // Full init similar to DwarfLab app
+    console.log('1. System init');
+    sendPacket(4, 13000, 1, '089a888acd06110000000000002240');
+    sendPacket(4, 13001, 1, '0a0a417369612f546f6b796f');
+    sendPacket(8, 15011, 1);
+    sendPacket(14, 16405, 1);
+    await sleep(500);
+
+    console.log('\n2. ModeSwitch (devId=4)');
+    sendPacket(14, 16404, 4, '1a020801');
+    await sleep(1000);
+
+    console.log('\n3. Open tele (CMD 10050, devId=4)');
+    sendPacket(1, 10050, 4, '0801');
+    await sleep(2000);
+
+    console.log('\n4. Open wide (CMD 12036, devId=4)');
+    sendPacket(2, 12036, 4);
+
+    console.log('\n5. Waiting 8s for streams to init...');
+    await sleep(8000);
+
+    // Probe RTSP (WS still alive)
+    console.log('\n6. Probing RTSP tele (ch0/stream0) with WS alive:');
+    await probeRtsp(`rtsp://${IP}:554/ch0/stream0`);
+
+    console.log('\n7. Probing RTSP wide (ch1/stream0) with WS alive:');
+    await probeRtsp(`rtsp://${IP}:554/ch1/stream0`);
+
+    // Probe MJPEG
+    console.log('\n8. Probing MJPEG 8092/mainstream (3s):');
+    await probeMjpeg(8092, '/mainstream');
+
+    console.log('\n9. Probing MJPEG 8092/secondstream (3s):');
+    await probeMjpeg(8092, '/secondstream');
+
+    console.log('\nDone. Closing WS.');
+    ws.close();
+    process.exit(0);
+  });
+
+  ws.on('error', (err) => console.error('WS Error:', err.message));
+  ws.on('close', (code) => console.log(`WS closed: ${code}`));
+
+  // Safety timeout
+  setTimeout(() => { ws.close(); process.exit(0); }, 40000);
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function probeRtsp(url) {
+  return new Promise(resolve => {
+    exec(`ffprobe -rtsp_transport tcp -i "${url}" -timeout 3000000 2>&1 | grep -E "Stream #|Session Not Found|Error opening"`, { timeout: 8000 }, (err, stdout) => {
+      console.log(stdout.trim() || '(no output)');
+      resolve();
+    });
+  });
+}
+
+function probeMjpeg(port, path) {
+  return new Promise(resolve => {
+    let bytes = 0;
+    let contentType = '';
+    const req = http.get(`http://${IP}:${port}${path}`, { timeout: 4000 }, (res) => {
+      contentType = res.headers['content-type'] || '';
+      res.on('data', (chunk) => { bytes += chunk.length; });
+    });
+    req.on('error', (e) => console.log(`  error: ${e.message}`));
+    setTimeout(() => {
+      req.destroy();
+      console.log(`  ${port}${path}: ${bytes} bytes, type: ${contentType}`);
+      resolve();
+    }, 3000);
+  });
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- dwarf-app#47 の調査で使用した Tele カメラストリーム検証スクリプトを追加
- DWARF mini の Tele が RTSP ではなく MJPEG (port 8092) で配信されることを実機で確認した際のツール

## Scripts
- `tele-test.cjs`: V3 カメラオープン + RTSP プローブ
- `tele-test2.cjs`: 応答データの詳細デコード付き
- `tele-test3.cjs`: フル初期化シーケンス + MJPEG/RTSP 両方プローブ

🤖 Generated with [Claude Code](https://claude.com/claude-code)