### PR TITLE
feat: decode paramId in pcap-decode output

### DIFF
--- a/src/paramid_utils.js
+++ b/src/paramid_utils.js
@@ -1,0 +1,70 @@
+/** @module paramid_utils */
+// Standalone paramId encode/decode utilities.
+// No protobuf or other heavy dependencies — safe to import from CLI tools.
+
+/**
+ * Encode a paramId from its constituent parts.
+ *
+ * paramId layout (64-bit):
+ *   bits 63..56 = shootingMode  (e.g. 0=photo, 1=video, 2=astro)
+ *   bits 55..48 = category      (parameter group)
+ *   bits 47..16 = reserved (0)
+ *   bits 15..8  = cameraId      (0=tele, 1=wide)
+ *   bits 7..0   = paramIndex    (parameter index within the category)
+ *
+ * Returns a decimal string suitable for protobuf.js int64 fields.
+ *
+ * @param {number} shootingMode - Shooting mode (0=photo, 1=video, 2=astro)
+ * @param {number} category - Parameter category
+ * @param {number} cameraId - Camera ID (0=tele, 1=wide)
+ * @param {number} paramIndex - Parameter index within the category
+ * @returns {string} Encoded paramId as decimal string
+ */
+export function encodeParamId(shootingMode, category, cameraId, paramIndex) {
+  const id =
+    (BigInt(shootingMode & 0xff) << 56n) |
+    (BigInt(category & 0xff) << 48n) |
+    (BigInt(cameraId & 0xff) << 8n) |
+    BigInt(paramIndex & 0xff);
+  return id.toString();
+}
+
+/**
+ * Decode a paramId into its constituent parts.
+ *
+ * Accepts number, string (decimal), BigInt, or protobuf.js Long object.
+ *
+ * @param {number|string|BigInt|{low: number, high: number}} paramId - Encoded parameter ID
+ * @returns {{ shootingMode: number, category: number, cameraId: number, paramIndex: number }}
+ */
+export function decodeParamId(paramId) {
+  let id;
+  if (typeof paramId === "bigint") {
+    id = paramId;
+  } else if (typeof paramId === "string") {
+    id = BigInt(paramId);
+  } else if (typeof paramId === "number") {
+    if (!Number.isSafeInteger(paramId)) {
+      throw new RangeError(
+        "paramId as number exceeds Number.MAX_SAFE_INTEGER; pass a string or BigInt instead"
+      );
+    }
+    id = BigInt(paramId);
+  } else if (
+    paramId &&
+    typeof /** @type {*} */ (paramId).low === "number" &&
+    typeof /** @type {*} */ (paramId).high === "number"
+  ) {
+    // protobuf.js Long object
+    const long = /** @type {{low: number, high: number}} */ (paramId);
+    id = (BigInt(long.high >>> 0) << 32n) | BigInt(long.low >>> 0);
+  } else {
+    throw new TypeError("paramId must be a number, string, BigInt, or Long");
+  }
+  return {
+    shootingMode: Number((id >> 56n) & 0xffn),
+    category: Number((id >> 48n) & 0xffn),
+    cameraId: Number((id >> 8n) & 0xffn),
+    paramIndex: Number(id & 0xffn),
+  };
+}

--- a/tools/v3-probe/pcap-decode.js
+++ b/tools/v3-probe/pcap-decode.js
@@ -7,6 +7,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { execSync } from "child_process";
 import { log, hexPreview } from "./common.js";
+import { decodeParamId } from "../../src/v3_camera_params.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROTO_DIR = path.resolve(__dirname, "../../src/proto");
@@ -178,7 +179,7 @@ const INNER_TYPES = {
   "16706:3": "ComResponse",
 };
 
-// ParamId decoder for human-readable display
+// ParamId decoder for human-readable display (uses shared decodeParamId)
 const PARAM_INDEX_NAMES = {
   0x0d: "filterWheel",
 };
@@ -187,11 +188,7 @@ const CAMERA_ID_NAMES = ["tele", "wide"];
 
 function formatParamId(paramId) {
   try {
-    const id = BigInt(paramId);
-    const shootingMode = Number((id >> 56n) & 0xffn);
-    const category = Number((id >> 48n) & 0xffn);
-    const cameraId = Number((id >> 8n) & 0xffn);
-    const paramIndex = Number(id & 0xffn);
+    const { shootingMode, category, cameraId, paramIndex } = decodeParamId(String(paramId));
     const modeName = SHOOTING_MODE_NAMES[shootingMode] || `mode${shootingMode}`;
     const camName = CAMERA_ID_NAMES[cameraId] || `cam${cameraId}`;
     const idxName = PARAM_INDEX_NAMES[paramIndex] || `idx${paramIndex}`;
@@ -370,8 +367,9 @@ async function main() {
                 longs: String, enums: String, bytes: String, defaults: true,
               });
               // Filter out zero/empty values for compact display
+              // Note: longs: String causes int64 zeros to arrive as "0"
               const nz = Object.entries(inner).filter(([, v]) =>
-                v !== 0 && v !== "" && v !== false && v !== null
+                v !== 0 && v !== "0" && v !== "" && v !== false && v !== null
               );
               if (nz.length > 0) {
                 // Decode paramId for human-readable display

--- a/tools/v3-probe/pcap-decode.js
+++ b/tools/v3-probe/pcap-decode.js
@@ -178,6 +178,29 @@ const INNER_TYPES = {
   "16706:3": "ComResponse",
 };
 
+// ParamId decoder for human-readable display
+const PARAM_INDEX_NAMES = {
+  0x0d: "filterWheel",
+};
+const SHOOTING_MODE_NAMES = ["photo", "video", "astro"];
+const CAMERA_ID_NAMES = ["tele", "wide"];
+
+function formatParamId(paramId) {
+  try {
+    const id = BigInt(paramId);
+    const shootingMode = Number((id >> 56n) & 0xffn);
+    const category = Number((id >> 48n) & 0xffn);
+    const cameraId = Number((id >> 8n) & 0xffn);
+    const paramIndex = Number(id & 0xffn);
+    const modeName = SHOOTING_MODE_NAMES[shootingMode] || `mode${shootingMode}`;
+    const camName = CAMERA_ID_NAMES[cameraId] || `cam${cameraId}`;
+    const idxName = PARAM_INDEX_NAMES[paramIndex] || `idx${paramIndex}`;
+    return `${modeName}/cat${category}/${camName}/${idxName}`;
+  } catch {
+    return String(paramId);
+  }
+}
+
 async function loadProtoRoot() {
   const root = new protobuf.Root();
   const protoFiles = [
@@ -351,7 +374,11 @@ async function main() {
                 v !== 0 && v !== "" && v !== false && v !== null
               );
               if (nz.length > 0) {
-                innerStr = ` → ${innerTypeName}: ${JSON.stringify(Object.fromEntries(nz))}`;
+                // Decode paramId for human-readable display
+                const display = Object.fromEntries(
+                  nz.map(([k, v]) => k === "paramId" ? [k, formatParamId(v)] : [k, v])
+                );
+                innerStr = ` → ${innerTypeName}: ${JSON.stringify(display)}`;
               } else {
                 innerStr = ` → ${innerTypeName}: {}`;
               }

--- a/tools/v3-probe/pcap-decode.js
+++ b/tools/v3-probe/pcap-decode.js
@@ -7,7 +7,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { execSync } from "child_process";
 import { log, hexPreview } from "./common.js";
-import { decodeParamId } from "../../src/v3_camera_params.js";
+import { decodeParamId } from "../../src/paramid_utils.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROTO_DIR = path.resolve(__dirname, "../../src/proto");
@@ -188,7 +188,7 @@ const CAMERA_ID_NAMES = ["tele", "wide"];
 
 function formatParamId(paramId) {
   try {
-    const { shootingMode, category, cameraId, paramIndex } = decodeParamId(String(paramId));
+    const { shootingMode, category, cameraId, paramIndex } = decodeParamId(paramId);
     const modeName = SHOOTING_MODE_NAMES[shootingMode] || `mode${shootingMode}`;
     const camName = CAMERA_ID_NAMES[cameraId] || `cam${cameraId}`;
     const idxName = PARAM_INDEX_NAMES[paramIndex] || `idx${paramIndex}`;


### PR DESCRIPTION
## Summary
- Add `formatParamId()` to pcap-decode.js that decodes 64-bit paramId into human-readable format
- Display as `shootingMode/category/camera/paramName` (e.g. `astro/cat1/tele/filterWheel`)
- Known param indices shown by name (currently: `filterWheel` = 0x0D)

Before: `{"paramId":"144396663052566541","value":2}`
After: `{"paramId":"astro/cat1/tele/filterWheel","value":2}`

Closes #27

## Test plan
- [x] Verified with AcoVanConis pcap — filter wheel params decoded correctly
- [x] Unknown paramIndices fall back to `idx<N>` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)